### PR TITLE
 resources: set limits to the resource usage of the addons

### DIFF
--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -14,3 +14,10 @@ spec:
       enableInsecureLogin: true
       service:
         externalPort: 9090
+      resources:
+        limits:
+          cpu: 100m
+          memory: 300Mi
+        requests:
+          cpu: 50m
+          memory: 100Mi

--- a/templates/elasticsearch.yaml
+++ b/templates/elasticsearch.yaml
@@ -9,4 +9,32 @@ spec:
     chart: stable/elasticsearch
     values: |
       ---
-      # we currently provide no configuration options for elasticsearch
+      client:
+        heapSize: 1024m
+        resources:
+          limits:
+            cpu: 500m
+            memory: 2048Mi
+          requests:
+            cpu: 100m
+            memory: 1536Mi
+      master:
+        heapSize: 1024m
+        resources:
+          # need more cpu upon initialization, therefore burstable class
+          limits:
+            cpu: 1000m
+            memory: 2048Mi
+          requests:
+            cpu: 250m
+            memory: 1536Mi
+      data:
+        heapSize: 1536m
+        resources:
+          # need more cpu upon initialization, therefore burstable class
+          limits:
+            cpu: 1000m
+            memory: 4096Mi
+          requests:
+            cpu: 250m
+            memory: 2048Mi

--- a/templates/fluentbit.yaml
+++ b/templates/fluentbit.yaml
@@ -37,6 +37,8 @@ spec:
         input: |-
          Strip_Underscores true
       resources:
+        limits:
+          memory: 500Mi
         requests:
           # values extracted from a 1 output/1 input setup here:
           # https://github.com/fluent/fluent-bit-kubernetes-logging/blob/master/fluent-bit-daemonset-kafka-rest.yml

--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -21,3 +21,9 @@ spec:
         type: ClusterIP
         externalPort: 5601
         internalPort: 5601
+      resources:
+        # need more cpu upon initialization, therefore burstable class
+        limits:
+          cpu: 1000m
+        requests:
+          cpu: 100m

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -8,6 +8,25 @@ spec:
     chart: stable/prometheus-operator
     values: |
       ---
+      prometheus:
+        prometheusSpec:
+          resources:
+            # based on 10 running nodes with 30 pods each
+            limits:
+              cpu: 200m
+              memory: 1000Mi
+            requests:
+              cpu: 200m
+              memory: 1000Mi
+      alertmanager:
+        alertmanagerSpec:
+          resources:
+            limits:
+              cpu: 10m
+              memory: 50Mi
+            requests:
+              cpu: 10m
+              memory: 50Mi
       grafana:
         grafana.ini:
           server:
@@ -25,6 +44,14 @@ spec:
         service:
           type: ClusterIP
           port: 3000
+        resources:
+          # keep request = limit to keep this container in guaranteed class
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
         readinessProbe:
           httpGet:
             path: /api/health

--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -8,6 +8,11 @@ spec:
     chart: stable/traefik
     values: |
       ---
+      resources:
+        limits:
+          cpu: 300m
+        requests:
+          cpu: 150m
       rbac:
         enabled: true
       metrics:


### PR DESCRIPTION
I am starting to identify which are our resource requirements for a certain size of the cluster. However we should specify which is the ideal size for certain default values. Moreover, we could infer these initial values based on the size of the cluster.

related to: https://jira.mesosphere.com/browse/DCOS-53206
