### PR TITLE
dashboard: use kube-system namespace

### DIFF
--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -3,7 +3,7 @@ apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
 metadata:
   name: dashboard
-  namespace: kubeaddons
+  namespace: kube-system
 spec:
   chartReference:
     chart: stable/kubernetes-dashboard


### PR DESCRIPTION
This was incorrectly changed when moving configs to this repo. Reverting back so the pod works.