### PR TITLE
change prometheus retention to 7d

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -8,6 +8,9 @@ spec:
     chart: stable/prometheus-operator
     values: |
       ---
+      prometheus:
+        prometheusSpec:
+          retention: 7d
       grafana:
         grafana.ini:
           server:


### PR DESCRIPTION
Justin Barrick reports 10d to be pretty high,
due to prometheus resource consumption