### PR TITLE
fix grafana role, using wrong key

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -21,7 +21,7 @@ spec:
           auth.basic:
             enabled: false
           users:
-            auto_assign_role: Admin
+            auto_assign_org_role: Admin
         service:
           type: ClusterIP
           port: 3000


### PR DESCRIPTION
as shown in the docs: https://grafana.com/docs/installation/configuration/#auto-assign-org-role

I can't find `auto_assign_role`. tested within my kind cluster.