### PR TITLE
grafana: disable AppArmor PSP

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -65,6 +65,8 @@ spec:
           initialDelaySeconds: 60
           timeoutSeconds: 30
           failureThreshold: 10
+        rbac:
+          pspUseAppArmor: false
       kubeEtcd:
         enabled: false
       prometheus:


### PR DESCRIPTION
After enabling PSP, saw a failure with on of the pods.
```
Name:               prometheus-kubeaddons-grafana-7bfb99cc8b-bvvdn
Namespace:          kubeaddons
Reason:             AppArmor
Message:            Cannot enforce AppArmor: AppArmor is not enabled on the host
```