### PR TITLE
elasticsearch: disabled data drain and update strategy

### DIFF
--- a/templates/elasticsearch.yaml
+++ b/templates/elasticsearch.yaml
@@ -21,6 +21,8 @@ spec:
             cpu: 100m
             memory: 1536Mi
       master:
+        updateStrategy:
+          type: RollingUpdate
         heapSize: 1024m
         resources:
           # need more cpu upon initialization, therefore burstable class
@@ -31,6 +33,8 @@ spec:
             cpu: 250m
             memory: 1536Mi
       data:
+        updateStrategy:
+          type: RollingUpdate
         hooks:
           drain:
             enabled: false

--- a/templates/elasticsearch.yaml
+++ b/templates/elasticsearch.yaml
@@ -31,6 +31,9 @@ spec:
             cpu: 250m
             memory: 1536Mi
       data:
+        hooks:
+          drain:
+            enabled: false
         heapSize: 1536m
         resources:
           # need more cpu upon initialization, therefore burstable class


### PR DESCRIPTION
We should consider if we want this disabled by default even when using local storage, or change it to be a configurable value.