### PR TITLE
name format error fixes

### DIFF
--- a/templates/opsportal.yaml
+++ b/templates/opsportal.yaml
@@ -2,7 +2,7 @@
 apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
 metadata:
-  name: opsPortal
+  name: opsportal
   namespace: kubeaddons
 spec:
   kubernetes:


### PR DESCRIPTION
uppercase is not valid for Kubernetes names.

tested with my own cluster.