### PR TITLE
Add metrics-server addon

### DIFF
--- a/templates/metricsserver.yaml
+++ b/templates/metricsserver.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1alpha1
+kind: Addon
+metadata:
+  name: metricsserver
+  namespace: kubeaddons
+spec:
+  kubernetes:
+    minSupportedVersion: v1.14.0
+  namespace: kube-system
+  chartReference:
+    chart: stable/metrics-server
+    values: |
+      ---
+      args:
+      # enable this if you have self-signed certificates, see: https://github.com/kubernetes-incubator/metrics-server
+      - --kubelet-insecure-tls


### PR DESCRIPTION
This enables HPA and `kubectl top` and dashboards in the kubernetes-dashboard.