### PR TITLE
calico: use default namespace

### DIFF
--- a/templates/calico.yaml
+++ b/templates/calico.yaml
@@ -3,7 +3,7 @@ apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
 metadata:
   name: calico
-  namespace: kube-system
+  namespace: kubeaddons
 spec:
   manifest: |
     ---


### PR DESCRIPTION
Use the default namespace.

Fixes https://jira.mesosphere.com/browse/DCOS-54029, requires additional changes in `kubeaddons`.