### PR TITLE
prometheus: use a PVC instead of an emptyDir

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -12,6 +12,15 @@ spec:
       ---
       prometheus:
         prometheusSpec:
+          externalUrl: "/ops/portal/prometheus"
+          storageSpec:
+            volumeClaimTemplate:
+              spec:
+                accessModes: ["ReadWriteOnce"]
+                # 50Gi is the default size for the chart
+                resources:
+                  requests:
+                    storage: 50Gi
           resources:
             # based on 10 running nodes with 30 pods each
             limits:
@@ -71,6 +80,3 @@ spec:
           pspUseAppArmor: false
       kubeEtcd:
         enabled: false
-      prometheus:
-        prometheusSpec:
-          externalUrl: "/ops/portal/prometheus"


### PR DESCRIPTION
Fixes https://jira.mesosphere.com/browse/DCOS-54042

Tested locally, the storage size is the default value:

```
➜  dkphoenix002 k describe pvc -n kubeaddons prometheus-prometheus-kubeaddons-prom-prometheus-db-prometheus-prometheus-kubeaddons-prom-prometheus-0
Name:          prometheus-prometheus-kubeaddons-prom-prometheus-db-prometheus-prometheus-kubeaddons-prom-prometheus-0
Namespace:     kubeaddons
StorageClass:  ebs-csi-driver
Status:        Bound
Volume:        pvc-c6b138a5-7b47-11e9-865c-0aed50195db4
Labels:        app=prometheus
               prometheus=prometheus-kubeaddons-prom-prometheus
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: ebs.csi.aws.com
               volume.kubernetes.io/selected-node: ip-10-0-130-141.us-west-2.compute.internal
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      50Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Events:
  Type       Reason                 Age                From                                                                       Message
  ----       ------                 ----               ----                                                                       -------
  Normal     WaitForFirstConsumer   77s (x2 over 77s)  persistentvolume-controller                                                waiting for first consumer to be created before binding
  Normal     ExternalProvisioning   77s                persistentvolume-controller                                                waiting for a volume to be created, either by external provisioner "ebs.csi.aws.com" or manually created by system administrator
  Normal     Provisioning           77s                ebs.csi.aws.com_ebs-csi-controller-0_5e475c9a-7b47-11e9-a0c3-b2ced459a925  External provisioner is provisioning volume for claim "kubeaddons/prometheus-prometheus-kubeaddons-prom-prometheus-db-prometheus-prometheus-kubeaddons-prom-prometheus-0"
  Normal     ProvisioningSucceeded  70s                ebs.csi.aws.com_ebs-csi-controller-0_5e475c9a-7b47-11e9-a0c3-b2ced459a925  Successfully provisioned volume pvc-c6b138a5-7b47-11e9-865c-0aed50195db4
Mounted By:  prometheus-prometheus-kubeaddons-prom-prometheus-0
```