### PR TITLE
[prometheus] namespace service monitor

### DIFF
--- a/templates/elasticsearchexporter.yaml
+++ b/templates/elasticsearchexporter.yaml
@@ -9,8 +9,15 @@ spec:
     minSupportedVersion: v1.14.0
   chartReference:
     chart: stable/elasticsearch-exporter
+    version: 1.2.0
     values: |
       ---
+      es:
+        uri: http://elasticsearch-kubeaddons-client:9200
+      image:
+        repository: justwatch/elasticsearch_exporter
+        tag: 1.0.2
+        pullPolicy: IfNotPresent
       serviceMonitor:
         enabled: true
         interval: 30s

--- a/templates/elasticsearchexporter.yaml
+++ b/templates/elasticsearchexporter.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1alpha1
+kind: Addon
+metadata:
+  name: elasticsearchexporter
+  namespace: kubeaddons
+spec:
+  kubernetes:
+    minSupportedVersion: v1.14.0
+  chartReference:
+    chart: stable/elasticsearch-exporter
+    values: |
+      ---
+      serviceMonitor:
+        enabled: true
+        interval: 30s

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -12,6 +12,17 @@ spec:
     values: |
       ---
       prometheus:
+        additionalServiceMonitors:
+          - name: traefik-monitor
+            selector:
+              matchLabels:
+                release: traefik-kubeaddons
+            namespaceSelector:
+              matchNames:
+                - kubeaddons
+            endpoints:
+              - port: metrics
+                interval: 10s
         prometheusSpec:
           externalUrl: "/ops/portal/prometheus"
           storageSpec:

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -13,16 +13,16 @@ spec:
       ---
       prometheus:
         additionalServiceMonitors:
-          - name: traefik-monitor
+          - name: kubeaddons-service-monitor
             selector:
               matchLabels:
-                release: traefik-kubeaddons
+                kubeaddons.mesosphere.io/servicemonitor: "true"
             namespaceSelector:
               matchNames:
                 - kubeaddons
             endpoints:
               - port: metrics
-                interval: 10s
+                interval: 30s
         prometheusSpec:
           externalUrl: "/ops/portal/prometheus"
           storageSpec:

--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -11,6 +11,9 @@ spec:
     version: 1.68.4
     values: |
       ---
+      service:
+        labels:
+          kubeaddons.mesosphere.io/servicemonitor: "true"
       metrics:
         prometheus:
           enabled: true


### PR DESCRIPTION
As discussed with Jie, we will add a service monitor that would aim to collect the info from the kubeaddons namespace and for a specific label. Therefore any service exposing a metrics endpoint and with a label `kubeaddons.mesosphere.io/servicemonitor: "true"` should be scrapped.