### PR TITLE
Improve Traefik Fault Tolerance

### DIFF
--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -11,7 +11,7 @@ spec:
     version: 1.68.4
     values: |
       ---
-      replicas: 3
+      replicas: 2
       service:
         labels:
           kubeaddons.mesosphere.io/servicemonitor: "true"

--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -11,6 +11,7 @@ spec:
     version: 1.68.4
     values: |
       ---
+      replicas: 3
       service:
         labels:
           kubeaddons.mesosphere.io/servicemonitor: "true"


### PR DESCRIPTION
Increases the number of default traefik pods deployed to help reduce ingress downtime from individual node failures.