### PR TITLE
Add Velero

### DIFF
--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -1,0 +1,389 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1alpha1
+kind: Addon
+metadata:
+  name: velero
+  namespace: kubeaddons
+spec:
+  manifest: |
+    ---
+    apiVersion: v1
+    kind: List
+    metadata:
+      name: velero-crds
+      namespace: velero
+    items:
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        creationTimestamp: null
+        labels:
+          component: velero
+        name: schedules.velero.io
+      spec:
+        group: velero.io
+        names:
+          kind: Schedule
+          plural: schedules
+        scope: Namespaced
+        version: v1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        creationTimestamp: null
+        labels:
+          component: velero
+        name: downloadrequests.velero.io
+      spec:
+        group: velero.io
+        names:
+          kind: DownloadRequest
+          plural: downloadrequests
+        scope: Namespaced
+        version: v1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        creationTimestamp: null
+        labels:
+          component: velero
+        name: podvolumebackups.velero.io
+      spec:
+        group: velero.io
+        names:
+          kind: PodVolumeBackup
+          plural: podvolumebackups
+        scope: Namespaced
+        version: v1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        creationTimestamp: null
+        labels:
+          component: velero
+        name: backupstoragelocations.velero.io
+      spec:
+        group: velero.io
+        names:
+          kind: BackupStorageLocation
+          plural: backupstoragelocations
+        scope: Namespaced
+        version: v1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        creationTimestamp: null
+        labels:
+          component: velero
+        name: serverstatusrequests.velero.io
+      spec:
+        group: velero.io
+        names:
+          kind: ServerStatusRequest
+          plural: serverstatusrequests
+        scope: Namespaced
+        version: v1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        creationTimestamp: null
+        labels:
+          component: velero
+        name: backups.velero.io
+      spec:
+        group: velero.io
+        names:
+          kind: Backup
+          plural: backups
+        scope: Namespaced
+        version: v1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        creationTimestamp: null
+        labels:
+          component: velero
+        name: restores.velero.io
+      spec:
+        group: velero.io
+        names:
+          kind: Restore
+          plural: restores
+        scope: Namespaced
+        version: v1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        creationTimestamp: null
+        labels:
+          component: velero
+        name: deletebackuprequests.velero.io
+      spec:
+        group: velero.io
+        names:
+          kind: DeleteBackupRequest
+          plural: deletebackuprequests
+        scope: Namespaced
+        version: v1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        creationTimestamp: null
+        labels:
+          component: velero
+        name: podvolumerestores.velero.io
+      spec:
+        group: velero.io
+        names:
+          kind: PodVolumeRestore
+          plural: podvolumerestores
+        scope: Namespaced
+        version: v1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        creationTimestamp: null
+        labels:
+          component: velero
+        name: resticrepositories.velero.io
+      spec:
+        group: velero.io
+        names:
+          kind: ResticRepository
+          plural: resticrepositories
+        scope: Namespaced
+        version: v1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        creationTimestamp: null
+        labels:
+          component: velero
+        name: volumesnapshotlocations.velero.io
+      spec:
+        group: velero.io
+        names:
+          kind: VolumeSnapshotLocation
+          plural: volumesnapshotlocations
+        scope: Namespaced
+        version: v1
+    ---
+    apiVersion: v1
+    kind: List
+    metadata:
+      name: velero-minio
+      namespace: velero
+    items:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: velero-minio-storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50Gi
+    - apiVersion: apps/v1beta1
+      kind: Deployment
+      metadata:
+        namespace: velero
+        name: minio
+        labels:
+          component: minio
+      spec:
+        strategy:
+          type: Recreate
+        template:
+          metadata:
+            labels:
+              component: minio
+          spec:
+            volumes:
+            - name: storage
+              persistentVolumeClaim:
+                claimName: velero-minio-storage
+            - name: config
+              emptyDir: {}
+            containers:
+            - name: minio
+              image: minio/minio:latest
+              imagePullPolicy: IfNotPresent
+              args:
+              - server
+              - /storage
+              - --config-dir=/config
+              env:
+              - name: MINIO_ACCESS_KEY
+                value: "minio"
+              - name: MINIO_SECRET_KEY
+                value: "CHANGEME"
+              ports:
+              - containerPort: 9000
+              volumeMounts:
+              - name: storage
+                mountPath: "/storage"
+              - name: config
+                mountPath: "/config"
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        namespace: velero
+        name: minio
+        labels:
+          component: minio
+      spec:
+        type: ClusterIP
+        ports:
+          - port: 9000
+            targetPort: 9000
+            protocol: TCP
+        selector:
+          component: minio
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        namespace: velero
+        name: minio-setup
+        labels:
+          component: minio
+      spec:
+        template:
+          metadata:
+            name: minio-setup
+          spec:
+            restartPolicy: OnFailure
+            volumes:
+            - name: config
+              emptyDir: {}
+            containers:
+            - name: mc
+              image: minio/mc:latest
+              imagePullPolicy: IfNotPresent
+              command:
+              - /bin/sh
+              - -c
+              - "mc --config-dir=/config config host add velero http://minio:9000 minio CHANGEME && mc --config-dir=/config mb -p velero/velero"
+              volumeMounts:
+              - name: config
+                mountPath: "/config"
+    ---
+    apiVersion: v1
+    kind: List
+    metadata:
+      name: velero
+      namespace: velero
+    items:
+    - apiVersion: rbac.authorization.k8s.io/v1beta1
+      kind: ClusterRoleBinding
+      metadata:
+        creationTimestamp: null
+        labels:
+          component: velero
+        name: velero
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cluster-admin
+      subjects:
+      - kind: ServiceAccount
+        name: velero
+        namespace: velero
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        creationTimestamp: null
+        labels:
+          component: velero
+        name: velero
+        namespace: velero
+    - apiVersion: velero.io/v1
+      kind: BackupStorageLocation
+      metadata:
+        creationTimestamp: null
+        labels:
+          component: velero
+        name: default
+        namespace: velero
+      spec:
+        config:
+          region: minio
+          s3ForcePathStyle: "true"
+          s3Url: http://minio.velero.svc:9000
+        objectStorage:
+          bucket: velero
+          prefix: ""
+        provider: aws
+    - apiVersion: apps/v1beta1
+      kind: Deployment
+      metadata:
+        creationTimestamp: null
+        labels:
+          component: velero
+        name: velero
+        namespace: velero
+      spec:
+        selector:
+          matchLabels:
+            deploy: velero
+        strategy: {}
+        template:
+          metadata:
+            annotations:
+              prometheus.io/path: /metrics
+              prometheus.io/port: "8085"
+              prometheus.io/scrape: "true"
+            creationTimestamp: null
+            labels:
+              component: velero
+              deploy: velero
+          spec:
+            containers:
+            - args:
+              - server
+              command:
+              - /velero
+              env:
+              - name: VELERO_SCRATCH_DIR
+                value: /scratch
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /credentials/cloud
+              - name: AWS_SHARED_CREDENTIALS_FILE
+                value: /credentials/cloud
+              - name: AZURE_CREDENTIALS_FILE
+                value: /credentials/cloud
+              image: gcr.io/heptio-images/velero:v1.0.0
+              imagePullPolicy: IfNotPresent
+              name: velero
+              ports:
+              - containerPort: 8085
+                name: metrics
+              resources: {}
+              volumeMounts:
+              - mountPath: /plugins
+                name: plugins
+              - mountPath: /scratch
+                name: scratch
+              - mountPath: /credentials
+                name: minio-credentials
+            restartPolicy: Always
+            serviceAccountName: velero
+            volumes:
+            - emptyDir: {}
+              name: plugins
+            - emptyDir: {}
+              name: scratch
+            - name: minio-credentials
+              secret:
+                secretName: minio-credentials
+    ---
+    apiVersion: velero.io/v1
+    kind: Schedule
+    metadata:
+      name: daily-backup
+      namespace: velero
+    spec:
+      schedule: 0 1 * * *
+      template:
+        includedNamespaces:
+        - '*'


### PR DESCRIPTION
The purpose of this PR is to add Velero, and convert it from the old way we use to deploy it. This PR works to cover the following issues:

* Deal with flakiness in Minio deployments
* Isolate Velero Minio so that's its solely used by Velero
* Add persistent storage to Minio for backups
* Reduce custom logic for Velero, and move remaining logic to extraSteps
* Enable daily cluster-wide backups
* Converts the last few remaining workers so that we can fully deprecate the old style workers (after helm)

At this time its specifically being added using the manifest implementation to better couple together the related minio service and velero quickly and expediently, but [DCOS-54304](https://jira.mesosphere.com/browse/DCOS-54304) was created as a follow up to this to utilize helm and perhaps make upstream contributions to the charts to assist with our use case.
