### PR TITLE
prometheus-adapter: add adapter in replacement of metrics-server

### DIFF
--- a/templates/prometheusadapter.yaml
+++ b/templates/prometheusadapter.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1alpha1
+kind: Addon
+metadata:
+  name: prometheusadapter
+  namespace: kubeaddons
+spec:
+  kubernetes:
+    minSupportedVersion: v1.14.0
+  chartReference:
+    chart: stable/prometheus-adapter
+    version: 1.0.2
+    values: |
+      ---
+      prometheus:
+        url: http://prometheus-kubeaddons-prom-prometheus
+      metricsRelistInterval: 30s


### PR DESCRIPTION
As an alternative to #20, it has been discussed whether we want to deploy metrics-server with the overlaps that it includes when having prometheus-operator. Therefore there is an alternative https://github.com/DirectXMan12/k8s-prometheus-adapter. That seems to replace metrics-server and is maintained by RH and Google people.