### PR TITLE
prometheusadapter: bump the version to 1.0.3

### DIFF
--- a/templates/prometheusadapter.yaml
+++ b/templates/prometheusadapter.yaml
@@ -9,7 +9,7 @@ spec:
     minSupportedVersion: v1.14.0
   chartReference:
     chart: stable/prometheus-adapter
-    version: 1.0.2
+    version: 1.0.3
     values: |
       ---
       prometheus:


### PR DESCRIPTION
1.0.2 has a bug (https://github.com/helm/charts/issues/13716) which
would cause issues with, for instance, `kubectl api-resources`. The bug
was fixed in this PR (https://github.com/helm/charts/pull/14389)
upstream.

Bump the version to 1.0.3 which has the fix.