### PR TITLE
ebscsidriver: made sure it runs on all nodes

### DIFF
--- a/templates/awsebscsidriver.yaml
+++ b/templates/awsebscsidriver.yaml
@@ -281,6 +281,11 @@ spec:
           tolerations:
             - key: CriticalAddonsOnly
               operator: Exists
+            # Make sure ebs-csi-node gets scheduled on all nodes.
+            - effect: NoSchedule
+              operator: Exists
+            - effect: NoExecute
+              operator: Exists
           containers:
             - name: ebs-plugin
               securityContext:


### PR DESCRIPTION
This is similar to what calico daemonset does. If a node is tainted
(e.g., dedicated nodes for some service), we need to make sure csi ebs
driver is still running on that node.