### PR TITLE
fluentbit: add service labels

### DIFF
--- a/templates/fluentbit.yaml
+++ b/templates/fluentbit.yaml
@@ -9,7 +9,7 @@ spec:
     minSupportedVersion: v1.14.0
   chartReference:
     chart: stable/fluent-bit
-    version: 2.0.1
+    version: 2.0.5
     values: |
       ---
       backend:
@@ -29,6 +29,8 @@ spec:
       metrics:
         enabled: true
         service:
+          labels:
+            kubeaddons.mesosphere.io/servicemonitor: "true"
           annotations:
             prometheus.io/path: /api/v1/metrics/prometheus
             prometheus.io/port: "2020"


### PR DESCRIPTION
Add service labels to be discovered by Prometheus and scrape fluent-bit related metrics.