### PR TITLE
alert-manager: increase cpu limit

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -46,7 +46,7 @@ spec:
         alertmanagerSpec:
           resources:
             limits:
-              cpu: 10m
+              cpu: 100m
               memory: 50Mi
             requests:
               cpu: 10m


### PR DESCRIPTION
Normally, it should be enough increasing it to 50 millicores but we can set it to 100m in prevision of bigger clusters.

<img width="795" alt="Screen Shot 2019-06-03 at 11 06 02 AM" src="https://user-images.githubusercontent.com/3602792/58789949-9a111700-85ef-11e9-90ec-81b3003538b1.png">
