### PR TITLE
elasticsearch-exporter: temporally remove the labels

### DIFF
--- a/templates/elasticsearchexporter.yaml
+++ b/templates/elasticsearchexporter.yaml
@@ -19,7 +19,5 @@ spec:
         tag: 1.0.2
         pullPolicy: IfNotPresent
       service:
-        labels:
-          kubeaddons.mesosphere.io/servicemonitor: "true"
         metricsPort:
           name: metrics


### PR DESCRIPTION
This is a temporal PR to avoid the latest issue regarding yaml formatting.