### PR TITLE
prometheus-adapter: add resourceRules to fix HPA and kubectl top

### DIFF
--- a/templates/prometheusadapter.yaml
+++ b/templates/prometheusadapter.yaml
@@ -9,9 +9,36 @@ spec:
     minSupportedVersion: v1.14.0
   chartReference:
     chart: stable/prometheus-adapter
-    version: 1.0.3
+    version: 1.1.0
     values: |
       ---
       prometheus:
         url: http://prometheus-kubeaddons-prom-prometheus
       metricsRelistInterval: 30s
+      rules:
+        resource:
+          cpu:
+            containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
+            nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[1m])) by (<<.GroupBy>>)
+            resources:
+              overrides:
+                instance:
+                 resource: node
+                namespace:
+                 resource: namespace
+                pod_name:
+                 resource: pod
+            containerLabel: container_name
+          memory:
+            containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+            nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
+            resources:
+              overrides:
+                instance:
+                 resource: node
+                namespace:
+                 resource: namespace
+                pod_name:
+                 resource: pod
+            containerLabel: container_name
+          window: 1m


### PR DESCRIPTION
Fixes https://jira.mesosphere.com/browse/DCOS-54616

Requires https://github.com/helm/charts/pull/14508 to be merged in.

The rule came from https://github.com/DirectXMan12/k8s-prometheus-adapter/blob/master/deploy/manifests/custom-metrics-config-map.yaml#L73

Tested with https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/.