### PR TITLE
prometheus: enable the admin API by default

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -24,6 +24,7 @@ spec:
               - port: metrics
                 interval: 30s
         prometheusSpec:
+          enableAdminAPI: true
           secrets:
             - etcd-certs
           externalUrl: "/ops/portal/prometheus"


### PR DESCRIPTION
This admin API enables the deletion of time series, I am so confident on enabling by default. So it is your call :).