### PR TITLE
setup fluentbit-prometheus properly

### DIFF
--- a/templates/elasticsearchexporter.yaml
+++ b/templates/elasticsearchexporter.yaml
@@ -20,6 +20,6 @@ spec:
         pullPolicy: IfNotPresent
       service:
         labels:
-          kubeaddons.mesosphere.io/servicemonitor: "true"
+          servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
         metricsPort:
           name: metrics

--- a/templates/fluentbit.yaml
+++ b/templates/fluentbit.yaml
@@ -30,7 +30,7 @@ spec:
         enabled: true
         service:
           labels:
-            kubeaddons.mesosphere.io/servicemonitor: "true"
+            kubeaddons.mesosphere.io/fluentbitservicemonitor: "true"
           annotations:
             prometheus.io/path: /api/v1/metrics/prometheus
             prometheus.io/port: "2020"

--- a/templates/fluentbit.yaml
+++ b/templates/fluentbit.yaml
@@ -30,7 +30,7 @@ spec:
         enabled: true
         service:
           labels:
-            kubeaddons.mesosphere.io/fluentbitservicemonitor: "true"
+            servicemonitor.kubeaddons.mesosphere.io/path: "api__v1__metrics__prometheus"
       tolerations:
         - effect: NoSchedule
           operator: Exists

--- a/templates/fluentbit.yaml
+++ b/templates/fluentbit.yaml
@@ -31,10 +31,6 @@ spec:
         service:
           labels:
             kubeaddons.mesosphere.io/fluentbitservicemonitor: "true"
-          annotations:
-            prometheus.io/path: /api/v1/metrics/prometheus
-            prometheus.io/port: "2020"
-            prometheus.io/scrape: "true"
       tolerations:
         - effect: NoSchedule
           operator: Exists

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -21,7 +21,17 @@ spec:
               matchNames:
                 - kubeaddons
             endpoints:
-              - port: metrics
+              - path: metrics
+                interval: 30s
+          - name: fluentbit-service-monitor
+            selector:
+              matchLabels:
+                kubeaddons.mesosphere.io/fluentbitservicemonitor: "true"
+            namespaceSelector:
+              matchNames:
+                - kubeaddons
+            endpoints:
+              - path: api/v1/metrics/prometheus
                 interval: 30s
         prometheusSpec:
           enableAdminAPI: true

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -13,20 +13,20 @@ spec:
       ---
       prometheus:
         additionalServiceMonitors:
-          - name: kubeaddons-service-monitor
+          - name: kubeaddons-service-monitor-metrics
             selector:
               matchLabels:
-                kubeaddons.mesosphere.io/servicemonitor: "true"
+                servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
             namespaceSelector:
               matchNames:
                 - kubeaddons
             endpoints:
               - port: metrics
                 interval: 30s
-          - name: fluentbit-service-monitor
+          - name: kubeaddons-service-monitor-api-v1-metrics-prometheus
             selector:
               matchLabels:
-                kubeaddons.mesosphere.io/fluentbitservicemonitor: "true"
+                servicemonitor.kubeaddons.mesosphere.io/path: "api__v1__metrics__prometheus"
             namespaceSelector:
               matchNames:
                 - kubeaddons

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -21,7 +21,7 @@ spec:
               matchNames:
                 - kubeaddons
             endpoints:
-              - path: metrics
+              - port: metrics
                 interval: 30s
           - name: fluentbit-service-monitor
             selector:
@@ -31,7 +31,8 @@ spec:
               matchNames:
                 - kubeaddons
             endpoints:
-              - path: api/v1/metrics/prometheus
+              - path: /api/v1/metrics/prometheus
+                port: metrics
                 interval: 30s
         prometheusSpec:
           enableAdminAPI: true

--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -14,7 +14,7 @@ spec:
       replicas: 2
       service:
         labels:
-          kubeaddons.mesosphere.io/servicemonitor: "true"
+          servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
       metrics:
         prometheus:
           enabled: true


### PR DESCRIPTION
it wasn't pointing to the correct endpoint. 

The endpoint in fluent-bit is different than `/metrics` that is why we have to define the specific path `/api/metrics/prometheus`.