### PR TITLE
dashboard: increase resource limits for memory

### DIFF
--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -21,7 +21,7 @@ spec:
       resources:
         limits:
           cpu: 1000m
-          memory: 300Mi
+          memory: 1000Mi
         requests:
           cpu: 500m
-          memory: 100Mi
+          memory: 300Mi


### PR DESCRIPTION

![Screen Shot 2019-06-06 at 9 08 41 PM](https://user-images.githubusercontent.com/3602792/59059635-c0f57480-889f-11e9-9553-84a9d8840b1a.png)
Based on the recent MWT, we should increase the memory limits for the dashboard.