### PR TITLE
Separate Velero batch job

### DIFF
--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -240,33 +240,6 @@ spec:
             protocol: TCP
         selector:
           component: minio
-    - apiVersion: batch/v1
-      kind: Job
-      metadata:
-        namespace: velero
-        name: minio-setup
-        labels:
-          component: minio
-      spec:
-        template:
-          metadata:
-            name: minio-setup
-          spec:
-            restartPolicy: OnFailure
-            volumes:
-            - name: config
-              emptyDir: {}
-            containers:
-            - name: mc
-              image: minio/mc:latest
-              imagePullPolicy: IfNotPresent
-              command:
-              - /bin/sh
-              - -c
-              - "mc --config-dir=/config config host add velero http://minio:9000 minio CHANGEME && mc --config-dir=/config mb -p velero/velero"
-              volumeMounts:
-              - name: config
-                mountPath: "/config"
     ---
     apiVersion: v1
     kind: List
@@ -387,3 +360,31 @@ spec:
       template:
         includedNamespaces:
         - '*'
+    ---
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      namespace: velero
+      name: minio-setup
+      labels:
+        component: minio
+    spec:
+      template:
+        metadata:
+          name: minio-setup
+        spec:
+          restartPolicy: OnFailure
+          volumes:
+          - name: config
+            emptyDir: {}
+          containers:
+          - name: mc
+            image: minio/mc:latest
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - "mc --config-dir=/config config host add velero http://minio:9000 minio CHANGEME && mc --config-dir=/config mb -p velero/velero"
+            volumeMounts:
+            - name: config
+              mountPath: "/config"


### PR DESCRIPTION
The purpose of this task is to separate the Velero batch job from the lists so that it can be identified and operated on separately from the list items.