### PR TITLE
bump addons versions

### DIFF
--- a/templates/awsebscsidriver.yaml
+++ b/templates/awsebscsidriver.yaml
@@ -322,7 +322,7 @@ spec:
                 periodSeconds: 10
                 failureThreshold: 5
             - name: node-driver-registrar
-              image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
+              image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
               args:
                 - --csi-address=$(ADDRESS)
                 - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)

--- a/templates/calico.yaml
+++ b/templates/calico.yaml
@@ -510,7 +510,7 @@ spec:
             # It can be deleted if this is a fresh installation, or if you have already
             # upgraded to use calico-ipam.
             - name: upgrade-ipam
-              image: calico/cni:v3.6.1
+              image: calico/cni:v3.6.3
               command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
               env:
                 - name: KUBERNETES_NODE_NAME
@@ -530,7 +530,7 @@ spec:
             # This container installs the Calico CNI binaries
             # and CNI network config file on each node.
             - name: install-cni
-              image: calico/cni:v3.6.1
+              image: calico/cni:v3.6.3
               command: ["/install-cni.sh"]
               env:
                 # Name of the CNI config file to create.
@@ -566,7 +566,7 @@ spec:
             # container programs network policy and routes on each
             # host.
             - name: calico-node
-              image: calico/node:v3.6.1
+              image: calico/node:v3.6.3
               env:
                 # Use Kubernetes API as the backing datastore.
                 - name: DATASTORE_TYPE
@@ -724,7 +724,7 @@ spec:
           serviceAccountName: calico-kube-controllers
           containers:
             - name: calico-kube-controllers
-              image: calico/kube-controllers:v3.6.1
+              image: calico/kube-controllers:v3.6.3
               resources:
                 limits:
                   cpu: 100m


### PR DESCRIPTION
* New release from https://docs.projectcalico.org/v3.6/release-notes/
* Match [upstream version](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/deploy/kubernetes/manifest.yaml#L333)