### PR TITLE
calico: use host-local and pod subnet cidr

### DIFF
--- a/templates/calico.yaml
+++ b/templates/calico.yaml
@@ -34,10 +34,11 @@ spec:
               "type": "calico",
               "log_level": "info",
               "datastore_type": "kubernetes",
-              "nodename": "__KUBERNETES_NODE_NAME__",
+              "node_name": "__KUBERNETES_NODE_NAME__",
               "mtu": __CNI_MTU__,
               "ipam": {
-                "type": "calico-ipam"
+                "type": "host-local",
+                "subnet": "usePodCidr"
               },
               "policy": {
                   "type": "k8s"
@@ -603,9 +604,13 @@ spec:
                 # The default IPv4 pool to create on startup if none exists. Pod IPs will be
                 # chosen from this range. Changing this value after installation will have
                 # no effect. This should fall within `--cluster-cidr`.
-                - name: CALICO_IPV4POOL_CIDR
-                  value: "192.168.0.0/16"
+                #- name: CALICO_IPV4POOL_CIDR
+                # value: "10.233.64.0/18"
+                - name: NO_DEFAULT_POOLS
+                  value: "true"
                 # Disable file logging so `kubectl logs` works.
+                - name: USE_POD_CIDR
+                  value: "true"
                 - name: CALICO_DISABLE_FILE_LOGGING
                   value: "true"
                 # Set Felix endpoint to host default action to ACCEPT.


### PR DESCRIPTION
This instructs calico to use the defined pod subnet cidr instead of defining a hardcoded one.

Note: I am doing some additional tests for validation