### PR TITLE
prometheus: specify a volume name

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -41,6 +41,8 @@ spec:
           externalUrl: "/ops/portal/prometheus"
           storageSpec:
             volumeClaimTemplate:
+              metadata:
+                name: db
               spec:
                 accessModes: ["ReadWriteOnce"]
                 # 50Gi is the default size for the chart


### PR DESCRIPTION
By setting the name, the auto-generated name via the prometheus-operator will result in `db-prometheus-prometheus-kubeaddons-prom-prometheus-0` which contains 53chars.

```
E0625 04:15:15.056075       1 volume.go:128] Internal Server Error: failed to create volume 'pvc-d480ba57-96ff-11e9-9cea-0a44df461fe2': response: Service "pvc-d480ba57-96ff-11e9-9cea-0a44df461fe2-ctrl-svc" is invalid: metadata.labels: Invalid value: "prometheus-prometheus-kubeaddons-prom-prometheus-db-prometheus-prometheus-kubeaddons-prom-prometheus-0": must be no more than 63 characters
```

```
db-prometheus-prometheus-kubeaddons-prom-prometheus-0   Bound    pvc-66873662-30d8-4f1d-a9f9-c7863b97d7b3   50Gi       RWO            ebs-csi-driver   3m3s
```
