### PR TITLE
localvolumeprovisioner: add changes to scrape the metrics endpoint

### DIFF
--- a/helm/localvolumeprovisioner/templates/deployment.yaml
+++ b/helm/localvolumeprovisioner/templates/deployment.yaml
@@ -92,6 +92,10 @@ spec:
                   fieldPath: metadata.namespace
             - name: JOB_CONTAINER_IMAGE
               value: "quay.io/external_storage/local-volume-provisioner:v2.3.2"
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
           volumeMounts:
             - name: provisioner-config
               mountPath: /etc/provisioner/config

--- a/helm/localvolumeprovisioner/templates/service.yaml
+++ b/helm/localvolumeprovisioner/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: local-volume-provisioner-kubeaddons-metrics
+  namespace: kubeaddons
+  labels:
+    app: local-volume-provisioner
+    release: local-volume-provisioner-kubeaddons
+    servicemonitor.kubeaddons.mesosphere.io/path: metrics
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+  - port: 8080
+    targetPort: metrics
+    name: metrics
+    protocol: TCP
+  selector:
+    app: local-volume-provisioner


### PR DESCRIPTION
Add a service to collect all the metrics from the localvolumeprovisioner, so it can be scrapped by our default service monitor.