### PR TITLE
localvolumeprovisioner template points to chart repo

### DIFF
--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -8,8 +8,6 @@ spec:
   kubernetes:
     minSupportedVersion: v1.14.0
   chartReference:
-    chart: https://mesosphere.github.io/charts/stable/localvolumeprovisioner-0.1.0.tgz
-    # FIXME: Use the repo instead, once the index issues are resolved.
-    #chart: localvolumeprovisioner
-    #repo: https://mesosphere.github.io/charts/stable
-    version: 0.1.0
+    repo: https://gpaul.github.io/charts/stable
+    chart: localvolumeprovisioner
+    version: 0.1.1


### PR DESCRIPTION
This PR makes the localvolumeprovisioner template point to a helm chart repo.

It includes / supercedes https://github.com/mesosphere/kubeaddons-configs/pull/68

Once that PR lands, and this PRs dependencies in kubeaddons and  konvoy land, this PRs base should  be changed to `master` and merged.