### PR TITLE
templates/localvolumeprovisioner: bump chart version to 0.1.1

### DIFF
--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -8,6 +8,6 @@ spec:
   kubernetes:
     minSupportedVersion: v1.14.0
   chartReference:
-    chart: mesosphere.github.io/localvolumeprovisioner
+    chart: localvolumeprovisioner
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.1.0
+    version: 0.1.1


### PR DESCRIPTION
This PR bumps the localvolumeprovisioner chart version from v0.1.0 to v0.1.1.

It also changes the chart name to not include the name of the helm chart repository (which is implicitly set to the FQDN of the `repo:` field value.) 

Requires:
- [ ] https://github.com/mesosphere/kubeaddons/pull/276
- [ ] https://github.com/mesosphere/charts/pull/5