### PR TITLE
label generic capabilities

### DIFF
--- a/templates/awsebscsidriverstorageclass.yaml
+++ b/templates/awsebscsidriverstorageclass.yaml
@@ -4,6 +4,8 @@ kind: Addon
 metadata:
   name: awsebscsidriverstorageclass
   namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.com/provides: storageclass
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0

--- a/templates/awsebscsidriverstorageclassdefault.yaml
+++ b/templates/awsebscsidriverstorageclassdefault.yaml
@@ -4,6 +4,8 @@ kind: Addon
 metadata:
   name: awsebscsidriverstorageclassdefault
   namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.com/provides: storageclass
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0

--- a/templates/awsstorageclass.yaml
+++ b/templates/awsstorageclass.yaml
@@ -4,6 +4,8 @@ kind: Addon
 metadata:
   name: awsstorageclass
   namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.com/provides: storageclass
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0

--- a/templates/awsstorageclassdefault.yaml
+++ b/templates/awsstorageclassdefault.yaml
@@ -4,6 +4,8 @@ kind: Addon
 metadata:
   name: awsstorageclassdefault
   namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.com/provides: storageclass
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0

--- a/templates/calico.yaml
+++ b/templates/calico.yaml
@@ -4,6 +4,8 @@ kind: Addon
 metadata:
   name: calico
   namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.com/provides: cni
 spec:
   manifest: |
     ---

--- a/templates/localstorageclass.yaml
+++ b/templates/localstorageclass.yaml
@@ -4,6 +4,8 @@ kind: Addon
 metadata:
   name: localstorageclass
   namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.com/provides: storageclass
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0

--- a/templates/localstorageclassdefault.yaml
+++ b/templates/localstorageclassdefault.yaml
@@ -4,6 +4,8 @@ kind: Addon
 metadata:
   name: localstorageclassdefault
   namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.com/provides: storageclass
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0

--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -3,6 +3,8 @@ kind: Addon
 metadata:
   name: traefik
   namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.com/provides: ingresscontroller
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0


### PR DESCRIPTION
Some Addon requirements are generic: storageclass, cni, ingresscontroller, etc.
These could be replaced by other sets of software that provide the same
functionality so we don't want to configure dependencies to require
specific software packages, but rather a generic capability.

This patch adds labels that can be matched for a generic capability.