### PR TITLE
Add cloudProvider mapping

### DIFF
--- a/templates/awsebscsidriver.yaml
+++ b/templates/awsebscsidriver.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    aws: enabled
   manifest: |
     ---
     apiVersion: v1
@@ -34,7 +36,7 @@ spec:
         verbs: ["get", "list", "watch"]
       - apiGroups: [""]
         resources: ["nodes"]
-        verbs: ["get", "list", "watch"]        
+        verbs: ["get", "list", "watch"]
       - apiGroups: [""]
         resources: ["events"]
         verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/templates/awsebscsidriverstorageclass.yaml
+++ b/templates/awsebscsidriverstorageclass.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    aws: disabled
   manifest: |
     ---
     apiVersion: storage.k8s.io/v1

--- a/templates/awsebscsidriverstorageclassdefault.yaml
+++ b/templates/awsebscsidriverstorageclassdefault.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    aws: enabled
   manifest: |
     ---
     apiVersion: storage.k8s.io/v1

--- a/templates/awsstorageclass.yaml
+++ b/templates/awsstorageclass.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    aws: disabled
   manifest: |
     ---
     apiVersion: storage.k8s.io/v1

--- a/templates/awsstorageclassdefault.yaml
+++ b/templates/awsstorageclassdefault.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    aws: disabled
   manifest: |
     ---
     apiVersion: storage.k8s.io/v1

--- a/templates/dex-k8s-authenticator.yaml
+++ b/templates/dex-k8s-authenticator.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    all: disabled
   chartReference:
     chart: dex-k8s-authenticator
     repo: https://mesosphere.github.io/charts/staging

--- a/templates/dex.yaml
+++ b/templates/dex.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    all: disabled
   chartReference:
     chart: stable/dex
     version: 1.4.0

--- a/templates/elasticsearch.yaml
+++ b/templates/elasticsearch.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    aws: enabled
+    docker: disabled
+    none: enabled
   chartReference:
     chart: stable/elasticsearch
     version: 1.26.2

--- a/templates/elasticsearchexporter.yaml
+++ b/templates/elasticsearchexporter.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    aws: enabled
+    docker: disabled
+    none: enabled
   chartReference:
     chart: stable/elasticsearch-exporter
     version: 1.3.1

--- a/templates/fluentbit.yaml
+++ b/templates/fluentbit.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    aws: enabled
+    docker: disabled
+    none: enabled
   chartReference:
     chart: stable/fluent-bit
     version: 2.0.5

--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    aws: enabled
+    docker: disabled
+    none: enabled
   chartReference:
     chart: stable/kibana
     version: 3.0.0

--- a/templates/localstorageclass.yaml
+++ b/templates/localstorageclass.yaml
@@ -1,3 +1,5 @@
+### DEPRECATED ###
+# This Addon is deprecated in favor of localvolumeprovisioner
 ---
 apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
@@ -9,6 +11,8 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    all: disabled
   manifest: |
     ---
     apiVersion: v1

--- a/templates/localstorageclassdefault.yaml
+++ b/templates/localstorageclassdefault.yaml
@@ -1,3 +1,5 @@
+### DEPRECATED ###
+# This Addon is deprecated in favor of localvolumeprovisioner
 ---
 apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
@@ -9,6 +11,8 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    all: disabled
   manifest: |
     ---
     apiVersion: v1

--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    aws: disabled
+    docker: enabled
+    none: enabled
   chartReference:
     chart: localvolumeprovisioner
     repo: https://mesosphere.github.io/charts/stable

--- a/templates/metallb.yaml
+++ b/templates/metallb.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    docker: enabled
+    none: enabled
   chartReference:
     chart: stable/metallb
     version: 0.9.5

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -6,6 +6,10 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    aws: enabled
+    docker: disabled
+    none: enabled
   chartReference:
     chart: stable/prometheus-operator
     version: 5.10.0


### PR DESCRIPTION
The cloudProvider field will enable or disable this addon per supported
cloud provider (currently: aws, docker, or none).

Not specifying cloudProvider, or leaving it empty gives the same results
and using the special `all` provider like: `all: enabled`.