### PR TITLE
Port storage addons to charts repo from kubeaddons-config

### DIFF
--- a/templates/awsebscsiprovisioner.yaml
+++ b/templates/awsebscsiprovisioner.yaml
@@ -12,5 +12,5 @@ spec:
     minSupportedVersion: v1.14.0
   chartReference:
     chart: awsebscsiprovisioner
-    repo: https://gpaul.github.io/charts/stable
+    repo: https://mesosphere.github.io/charts/stable
     version: 0.1.0

--- a/templates/awsebscsiprovisioner.yaml
+++ b/templates/awsebscsiprovisioner.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1alpha1
+kind: Addon
+metadata:
+  name: awsebscsiprovisioner
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: awsebscsiprovisioner
+    kubeaddons.mesosphere.com/provides: storageclass
+spec:
+  kubernetes:
+    minSupportedVersion: v1.14.0
+  chartReference:
+    chart: awsebscsiprovisioner
+    repo: https://gpaul.github.io/charts/stable
+    version: 0.1.0

--- a/templates/awsebsprovisioner.yaml
+++ b/templates/awsebsprovisioner.yaml
@@ -12,5 +12,5 @@ spec:
     minSupportedVersion: v1.14.0
   chartReference:
     chart: awsebsprovisioner
-    repo: https://gpaul.github.io/charts/stable
+    repo: https://mesosphere.github.io/charts/stable
     version: 0.1.0

--- a/templates/awsebsprovisioner.yaml
+++ b/templates/awsebsprovisioner.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1alpha1
+kind: Addon
+metadata:
+  name: awsebsprovisioner
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: awsebsprovisioner
+    kubeaddons.mesosphere.com/provides: storageclass
+spec:
+  kubernetes:
+    minSupportedVersion: v1.14.0
+  chartReference:
+    chart: awsebsprovisioner
+    repo: https://gpaul.github.io/charts/stable
+    version: 0.1.0

--- a/templates/localpathprovisioner.yaml
+++ b/templates/localpathprovisioner.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1alpha1
+kind: Addon
+metadata:
+  name: localpathprovisioner
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: localpathprovisioner
+    kubeaddons.mesosphere.com/provides: storageclass
+spec:
+  kubernetes:
+    minSupportedVersion: v1.14.0
+  chartReference:
+    chart: localpathprovisioner
+    repo: https://gpaul.github.io/charts/stable
+    version: 0.1.0

--- a/templates/localpathprovisioner.yaml
+++ b/templates/localpathprovisioner.yaml
@@ -12,5 +12,5 @@ spec:
     minSupportedVersion: v1.14.0
   chartReference:
     chart: localpathprovisioner
-    repo: https://gpaul.github.io/charts/stable
+    repo: https://mesosphere.github.io/charts/stable
     version: 0.1.0


### PR DESCRIPTION
This PR consolidates the storage addons around the pattern that was pioneered by the localvolumeprovisioner addon:

- Instead of using a manifest, an addon now points to a helm chart in the mesosphere/charts repository.
- Instead of having separate addons for storage provisioners and storage classes, we only have addons for storage provisioners.
- Each addon defines an associated storage class. 
- Each addon supports the `storageclassdefault: true|false` configuration option. This option controls whether or not the associated storage class will be marked as the default storage class for the cluster.
- The name of the associated storage class matches the name of the addon.

The following addons were renamed or removed in the process:
- aws{storageclass,storageclassdefault} -> awsebsprovisioner
- awsebscsidriver{,storageclass,storageclassdefault} -> awsebscsiprovisioner
- local{storageclass,storageclassdefault} -> localpathprovisioner

This PR does not modify the `localvolumeprovisioner` addon, as that already has the intended structure.

This is the sibling PR to https://github.com/mesosphere/charts/pull/12, which adds the charts to the charts repository.