### PR TITLE
templates/dex-k8s-authenticator: bump to hide oidc client secret from users

### DIFF
--- a/templates/dex-k8s-authenticator.yaml
+++ b/templates/dex-k8s-authenticator.yaml
@@ -18,7 +18,7 @@ spec:
   chartReference:
     chart: dex-k8s-authenticator
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.1.1
+    version: 1.1.2
     values: |
       ---
       ingress:


### PR DESCRIPTION
A new version of the chart that deploys authenticator version that does not expose OAuth client secret to the authenticated user.

To override HTML templates in the official container this PR introduces new `ConfigMap` that injects custom version of HTML templates into the authenticator container.

JIRA: https://jira.mesosphere.com/browse/DCOS-56105
Chart PR: https://github.com/mesosphere/charts/pull/24