### PR TITLE
kommander: use available version

### DIFF
--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -19,4 +19,4 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.1.1
+    version: 0.1.0


### PR DESCRIPTION
the available version is 0.1.0 https://github.com/mesosphere/charts/tree/master/docs/stable