### PR TITLE
chore: reduce default resource sizing

### DIFF
--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -28,5 +28,5 @@ spec:
           cpu: 1000m
           memory: 1000Mi
         requests:
-          cpu: 500m
-          memory: 300Mi
+          cpu: 50m
+          memory: 30Mi

--- a/templates/elasticsearch.yaml
+++ b/templates/elasticsearch.yaml
@@ -24,38 +24,45 @@ spec:
     values: |
       ---
       client:
-        heapSize: 1024m
+        replicas: 1
+        heapSize: 512m
         resources:
           limits:
-            cpu: 500m
-            memory: 2048Mi
+            cpu: 1000m
+            memory: 1024Mi
           requests:
-            cpu: 100m
-            memory: 1536Mi
+            cpu: 200m
+            memory: 768Mi
       master:
+        replicas: 2
+        persistence:
+          size: "512Mi"
         updateStrategy:
           type: RollingUpdate
-        heapSize: 1024m
+        heapSize: 512m
         resources:
           # need more cpu upon initialization, therefore burstable class
           limits:
-            cpu: 2000m
-            memory: 2048Mi
+            cpu: 1000m
+            memory: 1024Mi
           requests:
-            cpu: 500m
-            memory: 1536Mi
+            cpu: 200m
+            memory: 768Mi
       data:
+        replicas: 1
+        persistence:
+          size: "2Gi"
         updateStrategy:
           type: RollingUpdate
         hooks:
           drain:
             enabled: false
-        heapSize: 3072m
+        heapSize: 768m
         resources:
           # need more cpu upon initialization, therefore burstable class
           limits:
-            cpu: 4000m
-            memory: 8192Mi
+            cpu: 2000m
+            memory: 1536Mi
           requests:
-            cpu: 1000m
-            memory: 4608Mi
+            cpu: 500m
+            memory: 1152Mi

--- a/templates/fluentbit.yaml
+++ b/templates/fluentbit.yaml
@@ -55,5 +55,5 @@ spec:
           # values extracted from a 1 output/1 input setup here:
           # https://github.com/fluent/fluent-bit-kubernetes-logging/blob/master/fluent-bit-daemonset-kafka-rest.yml
           # we double it for 1 output (es)/2 input (tail, systemd) as an approximation
-          cpu: 200m
+          cpu: 50m
           memory: 200Mi

--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -39,6 +39,6 @@ spec:
       resources:
         # need more cpu upon initialization, therefore burstable class
         limits:
-          cpu: 1000m
+          cpu: 500m
         requests:
-          cpu: 100m
+          cpu: 50m

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -75,7 +75,7 @@ spec:
                 # 50Gi is the default size for the chart
                 resources:
                   requests:
-                    storage: 50Gi
+                    storage: 1Gi
           resources:
             limits:
               cpu: 1000m
@@ -115,7 +115,7 @@ spec:
             cpu: 200m
             memory: 100Mi
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
         readinessProbe:
           httpGet:

--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -17,7 +17,7 @@ spec:
     version: 1.68.4
     values: |
       ---
-      replicas: 2
+      replicas: 1
       service:
         labels:
           servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
@@ -26,9 +26,9 @@ spec:
           enabled: true
       resources:
         limits:
-          cpu: 2000m
-        requests:
           cpu: 1000m
+        requests:
+          cpu: 100m
       rbac:
         enabled: true
       metrics:

--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -185,7 +185,7 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 50Gi
+            storage: 1Gi
     - apiVersion: apps/v1beta1
       kind: Deployment
       metadata:


### PR DESCRIPTION
So that the default setting would allow us to fit all addons on a single
laptop.

Tested on macOS. we can do a default install with docker provisioner
with all addon enabled (assuming we change number of worker node
to 2 by default, which we should do)