### PR TITLE
templates/dex: bump dex to include new theme

### DIFF
--- a/templates/dex.yaml
+++ b/templates/dex.yaml
@@ -23,7 +23,7 @@ spec:
       # Temprarily we're going to use our custom built container. Documentation
       # for how to build a new version: https://github.com/mesosphere/dex/blob/v2.17.0-mesosphere/README.mesosphere.md
       image: mesosphere/dex
-      imageTag: v2.17.0-3-g9a1ad-mesosphere
+      imageTag: v2.17.0-5-gcf38-mesosphere
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Bump dex container to include new mesosphere theme.

JIRA: https://jira.mesosphere.com/browse/DCOS-56022

The theme was merged in https://github.com/mesosphere/dex/pull/1