### PR TITLE
Convert Velero To Helm Chart Implementation

### DIFF
--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -1,3 +1,59 @@
+# ------------------------------------------------------------------------------
+# Velero
+#
+#
+# Velero is an open source backup and migration tool for Kubernetes.
+# See more about Velero at:
+#
+# * https://velero.io/
+# * https://github.com/heptio/velero
+# * https://github.com/helm/charts/tree/master/stable/velero
+#
+#
+# Implementation
+#
+#
+# Our implementation of Velero currently supports S3 backends for storage, and by default if no configuration overrides are
+# provided to point it at a backend other than the default, we will create and manage a distributed Minio (https://min.io/)
+# cluster which uses the default storage class for the cluster to maintain the backups.
+#
+# WARNING: using the default (fallback) backend is for testing purposes only and should not be used in production.
+#
+#
+# Testing
+#
+#
+# If you would like to test this Addon without deploying the suite of Addons you can deploy it to any cluster with the following:
+#
+#   export VELERO_VALUES="$(perl -MYAML::XS -e 'local $/; $y = Load <>; print $y->{spec}{chartReference}{values}' templates/velero.yaml)"
+#   export VELERO_VERSION="$(perl -MYAML::XS -e 'local $/; $y = Load <>; print $y->{spec}{chartReference}{version}' templates/velero.yaml)"
+#   echo "$VELERO_VALUES" | helm install --name velero --namespace velero stable/velero --version $VELERO_VERSION -f -
+#
+# Watch the pods and wait for everything to fully come online with:
+#
+#   kubectl -n velero get pods -w
+#
+# To use Velero via its' CLI tool, you'll need to download the tool from the repo:
+#
+#  * https://github.com/heptio/velero/releases
+#
+# You can view the default schedules with:
+#
+#   velero get schedules
+#
+# And schedule an initial backup with:
+#
+#   velero backup create initial-backup
+#
+# NOTE: By default we do not expose Velero or any of its components (e.g. Minio) outside of the cluster for security reasons.
+#       You'll need to utilize a proxy like `kubectl -n velero port-forward svc/minio 9000:9000` in order to do things like
+#       `velero backup download initial-backup`.
+#
+# Clean up when you're done with:
+#
+#   helm delete --purge velero
+#
+# ------------------------------------------------------------------------------
 ---
 apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
@@ -7,391 +63,42 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: velero
 spec:
+  namespace: velero
   kubernetes:
     minSupportedVersion: v1.14.0
   requires:
     matchLabels:
       kubeaddons.mesosphere.io/provides: defaultstorageclass
-  manifest: |
-    ---
-    apiVersion: v1
-    kind: List
-    metadata:
-      name: velero-crds
-      namespace: velero
-    items:
-    - apiVersion: apiextensions.k8s.io/v1beta1
-      kind: CustomResourceDefinition
-      metadata:
-        creationTimestamp: null
-        labels:
-          component: velero
-        name: schedules.velero.io
-      spec:
-        group: velero.io
-        names:
-          kind: Schedule
-          plural: schedules
-        scope: Namespaced
-        version: v1
-    - apiVersion: apiextensions.k8s.io/v1beta1
-      kind: CustomResourceDefinition
-      metadata:
-        creationTimestamp: null
-        labels:
-          component: velero
-        name: downloadrequests.velero.io
-      spec:
-        group: velero.io
-        names:
-          kind: DownloadRequest
-          plural: downloadrequests
-        scope: Namespaced
-        version: v1
-    - apiVersion: apiextensions.k8s.io/v1beta1
-      kind: CustomResourceDefinition
-      metadata:
-        creationTimestamp: null
-        labels:
-          component: velero
-        name: podvolumebackups.velero.io
-      spec:
-        group: velero.io
-        names:
-          kind: PodVolumeBackup
-          plural: podvolumebackups
-        scope: Namespaced
-        version: v1
-    - apiVersion: apiextensions.k8s.io/v1beta1
-      kind: CustomResourceDefinition
-      metadata:
-        creationTimestamp: null
-        labels:
-          component: velero
-        name: backupstoragelocations.velero.io
-      spec:
-        group: velero.io
-        names:
-          kind: BackupStorageLocation
-          plural: backupstoragelocations
-        scope: Namespaced
-        version: v1
-    - apiVersion: apiextensions.k8s.io/v1beta1
-      kind: CustomResourceDefinition
-      metadata:
-        creationTimestamp: null
-        labels:
-          component: velero
-        name: serverstatusrequests.velero.io
-      spec:
-        group: velero.io
-        names:
-          kind: ServerStatusRequest
-          plural: serverstatusrequests
-        scope: Namespaced
-        version: v1
-    - apiVersion: apiextensions.k8s.io/v1beta1
-      kind: CustomResourceDefinition
-      metadata:
-        creationTimestamp: null
-        labels:
-          component: velero
-        name: backups.velero.io
-      spec:
-        group: velero.io
-        names:
-          kind: Backup
-          plural: backups
-        scope: Namespaced
-        version: v1
-    - apiVersion: apiextensions.k8s.io/v1beta1
-      kind: CustomResourceDefinition
-      metadata:
-        creationTimestamp: null
-        labels:
-          component: velero
-        name: restores.velero.io
-      spec:
-        group: velero.io
-        names:
-          kind: Restore
-          plural: restores
-        scope: Namespaced
-        version: v1
-    - apiVersion: apiextensions.k8s.io/v1beta1
-      kind: CustomResourceDefinition
-      metadata:
-        creationTimestamp: null
-        labels:
-          component: velero
-        name: deletebackuprequests.velero.io
-      spec:
-        group: velero.io
-        names:
-          kind: DeleteBackupRequest
-          plural: deletebackuprequests
-        scope: Namespaced
-        version: v1
-    - apiVersion: apiextensions.k8s.io/v1beta1
-      kind: CustomResourceDefinition
-      metadata:
-        creationTimestamp: null
-        labels:
-          component: velero
-        name: podvolumerestores.velero.io
-      spec:
-        group: velero.io
-        names:
-          kind: PodVolumeRestore
-          plural: podvolumerestores
-        scope: Namespaced
-        version: v1
-    - apiVersion: apiextensions.k8s.io/v1beta1
-      kind: CustomResourceDefinition
-      metadata:
-        creationTimestamp: null
-        labels:
-          component: velero
-        name: resticrepositories.velero.io
-      spec:
-        group: velero.io
-        names:
-          kind: ResticRepository
-          plural: resticrepositories
-        scope: Namespaced
-        version: v1
-    - apiVersion: apiextensions.k8s.io/v1beta1
-      kind: CustomResourceDefinition
-      metadata:
-        creationTimestamp: null
-        labels:
-          component: velero
-        name: volumesnapshotlocations.velero.io
-      spec:
-        group: velero.io
-        names:
-          kind: VolumeSnapshotLocation
-          plural: volumesnapshotlocations
-        scope: Namespaced
-        version: v1
-    ---
-    apiVersion: v1
-    kind: List
-    metadata:
-      name: velero-minio
-      namespace: velero
-    items:
-    - apiVersion: v1
-      kind: PersistentVolumeClaim
-      metadata:
-        name: velero-minio-storage
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 50Gi
-    - apiVersion: apps/v1beta1
-      kind: Deployment
-      metadata:
-        namespace: velero
-        name: minio
-        labels:
-          component: minio
-      spec:
-        strategy:
-          type: Recreate
-        template:
-          metadata:
-            labels:
-              component: minio
-          spec:
-            volumes:
-            - name: storage
-              persistentVolumeClaim:
-                claimName: velero-minio-storage
-            - name: config
-              emptyDir: {}
-            containers:
-            - name: minio
-              image: minio/minio:latest
-              imagePullPolicy: IfNotPresent
-              args:
-              - server
-              - /storage
-              - --config-dir=/config
-              env:
-              - name: MINIO_ACCESS_KEY
-                value: "minio"
-              - name: MINIO_SECRET_KEY
-                value: "CHANGEME"
-              ports:
-              - containerPort: 9000
-              volumeMounts:
-              - name: storage
-                mountPath: "/storage"
-              - name: config
-                mountPath: "/config"
-    - apiVersion: v1
-      kind: Service
-      metadata:
-        namespace: velero
-        name: minio
-        labels:
-          component: minio
-      spec:
-        type: ClusterIP
-        ports:
-          - port: 9000
-            targetPort: 9000
-            protocol: TCP
-        selector:
-          component: minio
-    ---
-    apiVersion: v1
-    kind: List
-    metadata:
-      name: velero
-      namespace: velero
-    items:
-    - apiVersion: rbac.authorization.k8s.io/v1beta1
-      kind: ClusterRoleBinding
-      metadata:
-        creationTimestamp: null
-        labels:
-          component: velero
-        name: velero
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: cluster-admin
-      subjects:
-      - kind: ServiceAccount
-        name: velero
-        namespace: velero
-    - apiVersion: v1
-      kind: ServiceAccount
-      metadata:
-        creationTimestamp: null
-        labels:
-          component: velero
-        name: velero
-        namespace: velero
-    - apiVersion: velero.io/v1
-      kind: BackupStorageLocation
-      metadata:
-        creationTimestamp: null
-        labels:
-          component: velero
-        name: default
-        namespace: velero
-      spec:
-        config:
-          region: minio
-          s3ForcePathStyle: "true"
-          s3Url: http://minio.velero.svc:9000
-        objectStorage:
-          bucket: velero
-          prefix: ""
-        provider: aws
-    - apiVersion: apps/v1beta1
-      kind: Deployment
-      metadata:
-        creationTimestamp: null
-        labels:
-          component: velero
-        name: velero
-        namespace: velero
-      spec:
-        selector:
-          matchLabels:
-            deploy: velero
-        strategy: {}
-        template:
-          metadata:
-            annotations:
-              prometheus.io/path: /metrics
-              prometheus.io/port: "8085"
-              prometheus.io/scrape: "true"
-            creationTimestamp: null
-            labels:
-              component: velero
-              deploy: velero
-          spec:
-            containers:
-            - args:
-              - server
-              command:
-              - /velero
-              env:
-              - name: VELERO_SCRATCH_DIR
-                value: /scratch
-              - name: GOOGLE_APPLICATION_CREDENTIALS
-                value: /credentials/cloud
-              - name: AWS_SHARED_CREDENTIALS_FILE
-                value: /credentials/cloud
-              - name: AZURE_CREDENTIALS_FILE
-                value: /credentials/cloud
-              image: gcr.io/heptio-images/velero:v1.0.0
-              imagePullPolicy: IfNotPresent
-              name: velero
-              ports:
-              - containerPort: 8085
-                name: metrics
-              resources: {}
-              volumeMounts:
-              - mountPath: /plugins
-                name: plugins
-              - mountPath: /scratch
-                name: scratch
-              - mountPath: /credentials
-                name: minio-credentials
-            restartPolicy: Always
-            serviceAccountName: velero
-            volumes:
-            - emptyDir: {}
-              name: plugins
-            - emptyDir: {}
-              name: scratch
-            - name: minio-credentials
-              secret:
-                secretName: minio-credentials
-    ---
-    apiVersion: velero.io/v1
-    kind: Schedule
-    metadata:
-      name: daily-backup
-      namespace: velero
-    spec:
-      schedule: 0 1 * * *
-      template:
-        includedNamespaces:
-        - '*'
-    ---
-    apiVersion: batch/v1
-    kind: Job
-    metadata:
-      namespace: velero
-      name: minio-setup
-      labels:
-        component: minio
-    spec:
-      template:
-        metadata:
-          name: minio-setup
-        spec:
-          restartPolicy: OnFailure
-          volumes:
-          - name: config
-            emptyDir: {}
-          containers:
-          - name: mc
-            image: minio/mc:latest
-            imagePullPolicy: IfNotPresent
-            command:
-            - /bin/sh
-            - -c
-            - "mc --config-dir=/config config host add velero http://minio:9000 minio CHANGEME && mc --config-dir=/config mb -p velero/velero"
-            volumeMounts:
-            - name: config
-              mountPath: "/config"
+  chartReference:
+    chart: stable/velero
+    version: 2.1.1
+    values: |
+      ---
+      configuration:
+        provider: "aws"
+        backupStorageLocation:
+          name: "aws"
+          bucket: "velero"
+          config:
+            region: "fallback"     # enables non-production fallback minio backend
+            s3ForcePathStyle: true # allows usage of fallback backend
+            s3Url: http://minio.velero.svc:9000
+        volumeSnapshotLocation:
+          name: "aws"
+          config:
+            region: "fallback"
+      credentials:
+        secretContents:
+          cloud: "placeholder"
+      schedules:
+        default:
+          schedule: "0 0 * * *"
+      initContainers:
+        # initialize-velero manages deploying a fallback backend (e.g. Minio) for Velero if needed,
+        # and also will manage the credentials and secrets for that backend and Velero automatically.
+        - name: initialize-velero
+          image: kubeaddons/addon-initializer:v0.0.1-alpha
+          args: ["velero"]
+          env:
+          - name: "VELERO_MINIO_FALLBACK_SECRET_NAME"
+            value: "velero"

--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -19,40 +19,6 @@
 #
 # WARNING: using the default (fallback) backend is for testing purposes only and should not be used in production.
 #
-#
-# Testing
-#
-#
-# If you would like to test this Addon without deploying the suite of Addons you can deploy it to any cluster with the following:
-#
-#   export VELERO_VALUES="$(perl -MYAML::XS -e 'local $/; $y = Load <>; print $y->{spec}{chartReference}{values}' templates/velero.yaml)"
-#   export VELERO_VERSION="$(perl -MYAML::XS -e 'local $/; $y = Load <>; print $y->{spec}{chartReference}{version}' templates/velero.yaml)"
-#   echo "$VELERO_VALUES" | helm install --name velero --namespace velero stable/velero --version $VELERO_VERSION -f -
-#
-# Watch the pods and wait for everything to fully come online with:
-#
-#   kubectl -n velero get pods -w
-#
-# To use Velero via its' CLI tool, you'll need to download the tool from the repo:
-#
-#  * https://github.com/heptio/velero/releases
-#
-# You can view the default schedules with:
-#
-#   velero get schedules
-#
-# And schedule an initial backup with:
-#
-#   velero backup create initial-backup
-#
-# NOTE: By default we do not expose Velero or any of its components (e.g. Minio) outside of the cluster for security reasons.
-#       You'll need to utilize a proxy like `kubectl -n velero port-forward svc/minio 9000:9000` in order to do things like
-#       `velero backup download initial-backup`.
-#
-# Clean up when you're done with:
-#
-#   helm delete --purge velero
-#
 # ------------------------------------------------------------------------------
 ---
 apiVersion: kubeaddons.mesosphere.io/v1alpha1

--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -93,6 +93,10 @@ spec:
       schedules:
         default:
           schedule: "0 0 * * *"
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
       initContainers:
         # initialize-velero manages deploying a fallback backend (e.g. Minio) for Velero if needed,
         # and also will manage the credentials and secrets for that backend and Velero automatically.


### PR DESCRIPTION
This PR converts Velero to a chart based implementation and utilizes [extrasteps](https://github.com/kubeaddons/extrasteps) to deploy a non-production fallback Minio cluster for the Velero Addon if no other backend is provided.