### PR TITLE
Change rules to authenticate only Ops Portal

### DIFF
--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -44,10 +44,11 @@ spec:
               name: ops-portal-credentials
               key: username
         extraConfig: |
-          rule.path.action = allow
-          rule.path.rule = Path(`/favicon.ico`, `/token`)
-          rule.prefix.action = allow
-          rule.prefix.rule = PathPrefix(`/dex/`, `/token/`)
+          default-action = allow
+          rule.path.action = auth
+          rule.path.rule = Path(`/ops/portal`)
+          rule.prefix.action = auth
+          rule.prefix.rule = PathPrefix(`/ops/portal/`)
 
       ingress:
         enabled: true


### PR DESCRIPTION
Change the `traefik-forward-auth` rules to authenticate only the `/ops/portal` path, and allow all other paths.  This uses the `traefik-forward-auth` rules to do this.

Later, we plan to get `ingress` rules to handle this for us.
