### PR TITLE
Disable Velero ServiceMonitor

### DIFF
--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -61,8 +61,6 @@ spec:
           schedule: "0 0 * * *"
       metrics:
         enabled: true
-        serviceMonitor:
-          enabled: true
       initContainers:
         # initialize-velero manages deploying a fallback backend (e.g. Minio) for Velero if needed,
         # and also will manage the credentials and secrets for that backend and Velero automatically.

--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -61,6 +61,9 @@ spec:
           schedule: "0 0 * * *"
       metrics:
         enabled: true
+        # TODO - add the serviceMonitor to the default deployment
+        # serviceMonitor:
+        #   enabled: true
       initContainers:
         # initialize-velero manages deploying a fallback backend (e.g. Minio) for Velero if needed,
         # and also will manage the credentials and secrets for that backend and Velero automatically.


### PR DESCRIPTION
Enabling the ServiceMonitor requires the ServiceMonitor CRD to be deployed before hand. This can be done by deploying after Prometheus, however to make things work in the short term this PR simply disables it as a default setting for the time being.