### PR TITLE
grafana: use X-Forwarded-User for the auth header

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -109,7 +109,7 @@ spec:
             root_url: "%(protocol)s://%(domain)s:%(http_port)s/ops/portal/grafana"
           auth.proxy:
             enabled: true
-            header_name: X-WEBAUTH-USER
+            header_name: X-Forwarded-User
             auto-sign-up: true
           auth.basic:
             enabled: false


### PR DESCRIPTION
This is the header that traefik auth forwarder is using.
https://github.com/thomseddon/traefik-forward-auth#forwarded-headers