### PR TITLE
Use ingress annotations

### DIFF
--- a/templates/opsportal.yaml
+++ b/templates/opsportal.yaml
@@ -88,6 +88,10 @@ spec:
       annotations:
         kubernetes.io/ingress.class: traefik
         traefik.frontend.rule.type: PathPrefixStrip
+        traefik.ingress.kubernetes.io/auth-type: forward
+        traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
+        traefik.ingress.kubernetes.io/auth-trust-headers: false
+        traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
       name: ops-portal
       namespace: kubeaddons
     spec:
@@ -132,6 +136,10 @@ spec:
         kubernetes.io/ingress.class: traefik
         traefik.ingress.kubernetes.io/rewrite-target: /
         traefik.ingress.kubernetes.io/priority: "1"
+        traefik.ingress.kubernetes.io/auth-type: forward
+        traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
+        traefik.ingress.kubernetes.io/auth-trust-headers: false
+        traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
       name: opsportal-landing
       namespace: kubeaddons
     spec:

--- a/templates/opsportal.yaml
+++ b/templates/opsportal.yaml
@@ -90,7 +90,6 @@ spec:
         traefik.frontend.rule.type: PathPrefixStrip
         traefik.ingress.kubernetes.io/auth-type: forward
         traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
-        traefik.ingress.kubernetes.io/auth-trust-headers: false
         traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
       name: ops-portal
       namespace: kubeaddons
@@ -138,7 +137,6 @@ spec:
         traefik.ingress.kubernetes.io/priority: "1"
         traefik.ingress.kubernetes.io/auth-type: forward
         traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
-        traefik.ingress.kubernetes.io/auth-trust-headers: false
         traefik.ingress.kubernetes.io/auth-response-headers: X-Forwarded-User
       name: opsportal-landing
       namespace: kubeaddons

--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -16,7 +16,7 @@ spec:
 
       image:
         repository: jongiddy/traefik-forward-auth
-        tag: 1.0.1
+        tag: 1.0.2
         pullPolicy: IfNotPresent
 
       service:

--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -16,7 +16,7 @@ spec:
 
       image:
         repository: jongiddy/traefik-forward-auth
-        tag: 1.0.0
+        tag: 1.0.1
         pullPolicy: IfNotPresent
 
       service:
@@ -55,6 +55,8 @@ spec:
         annotations:
           kubernetes.io/ingress.class: traefik
           ingress.kubernetes.io/protocol: https
+          traefik.ingress.kubernetes.io/auth-type: forward
+          traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
         paths:
           - /_oauth
         hosts:

--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -59,9 +59,3 @@ spec:
         defaultCN: traefik.localhost.localdomain
         defaultSANList:
           - "*"
-      forwardAuth:
-        entryPoints:
-        - https
-        address: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
-        trustForwardHeader: false
-        authResponseHeaders: ["X-Forwarded-User"]


### PR DESCRIPTION
Set the Traefik forward auth configuration using ingress annotations. This removes the dependency of Traefik on `traefik-forward-auth`. If Ops Portal and `traefik-forward-auth` are both disabled, then Traefik should still work.