### PR TITLE
kommander: fix wrong annotation endpoint

### DIFF
--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -8,7 +8,7 @@ metadata:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
     appversion.kubeaddons.mesosphere.io/kommander: "1.24.2"
-    endpoint.kubeaddons.mesosphere.io/: /ops/portal/kommander
+    endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0


### PR DESCRIPTION
```
Error: error installing: error generating workflow from Addon list: failed to create workflow for https://github.com/mesosphere/kubeaddons-configs@hectorj2f/ingress-annotations: failed to deploy addon CRD kommander; error: deployConfig failed: exit status 1 [stderr: The Addon "kommander" is invalid:
* metadata.annotations: Invalid value: "endpoint.kubeaddons.mesosphere.io/": name part must be non-empty
* metadata.annotations: Invalid value: "endpoint.kubeaddons.mesosphere.io/": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')
]
```