### PR TITLE
Use a specific image for traefik-forward-auth

### DIFF
--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -16,8 +16,8 @@ spec:
 
       image:
         repository: jongiddy/traefik-forward-auth
-        tag: latest
-        pullPolicy: Always
+        tag: 1.0.0
+        pullPolicy: IfNotPresent
 
       service:
         type: ClusterIP


### PR DESCRIPTION
Use a specific tag for the `traefik-forward-auth` image. This provides some stability before moving the image to the `mesosphere` repo.
