### PR TITLE
fixes cloudProvider values found in specs

### DIFF
--- a/templates/localpathprovisioner.yaml
+++ b/templates/localpathprovisioner.yaml
@@ -14,7 +14,7 @@ spec:
     minSupportedVersion: v1.14.0
   cloudProvider:
     - name: none
-      enabled: true
+      enabled: false
   chartReference:
     chart: localpathprovisioner
     repo: https://mesosphere.github.io/charts/stable

--- a/templates/localpathprovisioner.yaml
+++ b/templates/localpathprovisioner.yaml
@@ -12,6 +12,9 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    - name: none
+      enabled: true
   chartReference:
     chart: localpathprovisioner
     repo: https://mesosphere.github.io/charts/stable

--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -13,8 +13,6 @@ spec:
   kubernetes:
     minSupportedVersion: v1.14.0
   cloudProvider:
-    - name: aws
-      enabled: false
     - name: docker
       enabled: true
     - name: none

--- a/templates/prometheusadapter.yaml
+++ b/templates/prometheusadapter.yaml
@@ -11,6 +11,13 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: true
   requires:
     matchLabels:
       kubeaddons.mesosphere.io/name: prometheus

--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -37,10 +37,8 @@ spec:
   cloudProvider:
     - name: aws
       enabled: true
-    - name: docker
-      enabled: false
     - name: none
-      enabled: false
+      enabled: true
   chartReference:
     chart: stable/velero
     version: 2.1.1


### PR DESCRIPTION
fixed velero so that is
- enabled in aws
- enabled in none
- not and addon in docker type.

fixed localpath and volume provisioners
- removed from aws deployment

prometheusadapter
- should reflect options found in prometheus