### PR TITLE
templates: bump kommander and adds a draft template for konvoy-ui

### DIFF
--- a/templates/konvoy-ui.yaml
+++ b/templates/konvoy-ui.yaml
@@ -8,7 +8,7 @@ metadata:
     kubeaddons.mesosphere.io/name: konvoy-ui
   annotations:
     appversion.kubeaddons.mesosphere.io/kommander: "1.40.0"
-    #endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal
+    endpoint.kubeaddons.mesosphere.io/landing: /landing
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
@@ -25,6 +25,15 @@ spec:
     version: 0.1.6
     values: |
       ---
+      service:
+        name: konvoy-ui
+      ingress:
+        paths:
+          # konvoy-ui
+          - backend:
+              serviceName: konvoy-ui
+              servicePort: 4000
+            path: /landing
   requires:
     matchLabels:
       kubeaddons.mesosphere.io/provides: defaultstorageclass

--- a/templates/konvoy-ui.yaml
+++ b/templates/konvoy-ui.yaml
@@ -2,13 +2,13 @@
 apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
 metadata:
-  name: kommander
+  name: konvoy-ui
   namespace: kubeaddons
   labels:
-    kubeaddons.mesosphere.io/name: kommander
+    kubeaddons.mesosphere.io/name: konvoy-ui
   annotations:
     appversion.kubeaddons.mesosphere.io/kommander: "1.40.0"
-    endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander
+    #endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
@@ -24,15 +24,7 @@ spec:
     repo: https://mesosphere.github.io/charts/stable
     version: 0.1.6
     values: |
-      service:
-        name: kommander
-      ingress:
-        paths:
-          # kommander
-          - backend:
-              serviceName: kommander
-              servicePort: 4000
-            path: /ops/portal/kommander
+      ---
   requires:
     matchLabels:
       kubeaddons.mesosphere.io/provides: defaultstorageclass


### PR DESCRIPTION
- [x] Bumps kommander versions to use the latest changes in mesosphere/charts (to be merged)
- [x] Adds a dummy `konvoy-ui` addon to the template `(THIS TEMPLATE NEEDS TO BE FILLED WITH THE RIGHT VALUES)`