### PR TITLE
Minor changes on Traefik's manifest

### DIFF
--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -26,9 +26,6 @@ spec:
       service:
         labels:
           servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
-      metrics:
-        prometheus:
-          enabled: true
       resources:
         limits:
           cpu: 2000m

--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     appversion.kubeaddons.mesosphere.io/traefik: "1.68.4"
     endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
-    docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/"
+    docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/v1.7"
 spec:
   kubernetes:
     minSupportedVersion: v1.14.0


### PR DESCRIPTION
Hi there, 

while reviewing your product, I stumbled across 2 minors thing in the Traefik's default manifest:

* The link to the documentation should point explicitly to the current stable `v1.7`, to avoid breaking when the brand new Traefik v2.0 will be released.
* There was a duplicated YAML stanza about prometheus metrics enablement.

Thanks for your work!