### PR TITLE
traefik-forward-auth: fix a bug in rules

### DIFF
--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -46,8 +46,6 @@ spec:
           rule.path.rule = Path(`/ops/portal`)
           rule.prefix.action = auth
           rule.prefix.rule = PathPrefix(`/ops/portal/`)
-          rule.path.action = allow
-          rule.path.rule = Path(`/ops/portal/landing`)
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
We should use a separate rule name for the landing page.