### PR TITLE
localvolumeprovisioner: allow for aws

### DIFF
--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -13,6 +13,8 @@ spec:
   kubernetes:
     minSupportedVersion: v1.14.0
   cloudProvider:
+    - name: aws
+      enabled: false
     - name: docker
       enabled: true
     - name: none


### PR DESCRIPTION
This is needed for AWS tests, but also a user on AWS might want to enable this.
@alejandroEsc what happens if both csi and this is enabled? Will the correct SC be set? 