### PR TITLE
Prepare to replace traefik forward auth with ingress annotations

### DIFF
--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -15,7 +15,7 @@ spec:
       replicaCount: 1
       image:
         repository: jongiddy/traefik-forward-auth
-        tag: 1.0.0
+        tag: 1.0.2
         pullPolicy: IfNotPresent
       service:
         type: ClusterIP
@@ -51,6 +51,8 @@ spec:
         annotations:
           kubernetes.io/ingress.class: traefik
           ingress.kubernetes.io/protocol: https
+          traefik.ingress.kubernetes.io/auth-type: forward
+          traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
         paths:
           - /_oauth
         hosts:

--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -56,9 +56,3 @@ spec:
         defaultCN: traefik.localhost.localdomain
         defaultSANList:
           - "*"
-      forwardAuth:
-        entryPoints:
-        - https
-        address: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
-        trustForwardHeader: false
-        authResponseHeaders: ["X-Forwarded-User"]


### PR DESCRIPTION
This PR removes authentication so that integration of the new konvoy-ui can get done.