### PR TITLE
kibana: bump sidecar version to support envs

### DIFF
--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -46,12 +46,3 @@ spec:
           cpu: 1000m
         requests:
           cpu: 100m
-      extraContainers: |-
-        - name: initialize-kibana-indices
-          image: kubeaddons/addon-initializer:v0.0.2-alpha
-          args: ["kibana"]
-          env:
-          - name: "KIBANA_NAMESPACE"
-            value: "kubeaddons"
-          - name: "KIBANA_SERVICE_NAME"
-            value: "kibana-kubeaddons"

--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -48,7 +48,7 @@ spec:
           cpu: 100m
       extraContainers: |-
         - name: initialize-kibana-indices
-          image: kubeaddons/addon-initializer:v0.0.1-alpha
+          image: kubeaddons/addon-initializer:v0.0.2-alpha
           args: ["kibana"]
           env:
           - name: "KIBANA_NAMESPACE"


### PR DESCRIPTION
Fails with below since `v0.0.1-alpha` doesn't support kibana or those envs
```
2019/07/20 01:46:22 can't yet reach kibana: Get http://kibana.kibana:5601: dial tcp: lookup kibana.kibana on 10.0.0.10:53: no such host
2019/07/20 01:46:22 waiting for kibana to be responsive
```

After updating the pod came up:
```
kibana-kubeaddons-588cc57fc4-84m26                                2/2     Running   3          16m
```