### PR TITLE
Remove redundant rules

### DIFF
--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -14,7 +14,7 @@ spec:
       ---
       replicaCount: 1
       image:
-        repository: jongiddy/traefik-forward-auth
+        repository: mesosphere/traefik-forward-auth
         tag: 1.0.2
         pullPolicy: IfNotPresent
       service:
@@ -40,12 +40,6 @@ spec:
             secretKeyRef:
               name: ops-portal-credentials
               key: username
-        extraConfig: |
-          default-action = allow
-          rule.path.action = auth
-          rule.path.rule = Path(`/ops/portal`)
-          rule.prefix.action = auth
-          rule.prefix.rule = PathPrefix(`/ops/portal/`)
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
Now that ingress annotations determine which parts of the site require authentication
we no longer need rules in traefik-forward-auth.

Also, change to use image from Mesosphere Docker Hub.