### PR TITLE
Export kommander metrics to Prometheus

### DIFF
--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -23,7 +23,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.1.14
+    version: 0.1.15
     values: |
       # do not install the crd, kubeaddons will
       createObservableClusterCRD: false

--- a/templates/konvoy-ui.yaml
+++ b/templates/konvoy-ui.yaml
@@ -22,7 +22,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.1.14
+    version: 0.1.15
     values: |
       createObservableClusterCRD: false
       mode: konvoy

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -43,6 +43,7 @@ spec:
             namespaceSelector:
               matchNames:
                 - kubeaddons
+                - kommander
             endpoints:
               - port: metrics
                 interval: 30s


### PR DESCRIPTION
Bump Kommander to the latest version which exports metrics, and add the kommander namespace to the Prometheus service monitor match configs to get the metric endpoints scraped.

![image](https://user-images.githubusercontent.com/5897740/61735407-be0fef80-ad38-11e9-9108-66d8e3674911.png)
