### PR TITLE
opsportal: bump chart version

### DIFF
--- a/templates/opsportal.yaml
+++ b/templates/opsportal.yaml
@@ -20,4 +20,4 @@ spec:
   chartReference:
     chart: opsportal
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.0.5
+    version: 0.0.6


### PR DESCRIPTION
related to: https://github.com/mesosphere/charts/pull/67

This PR adds the logo to the ops/landing page