### PR TITLE
kommander: bump chart version

### DIFF
--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -23,7 +23,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.1.19
+    version: 0.1.20
   requires:
     matchLabels:
       kubeaddons.mesosphere.io/provides: defaultstorageclass


### PR DESCRIPTION
Use the new version with reduced default CPU request.

xref: https://github.com/mesosphere/charts/pull/83