### PR TITLE
dex-k8s-authenticator: add missing ConfigMap value

### DIFF
--- a/templates/dex-k8s-authenticator.yaml
+++ b/templates/dex-k8s-authenticator.yaml
@@ -58,5 +58,5 @@ spec:
           value: cGxhY2Vob2xkZXIK # b64 "placeholder" this will be updated by initcontainers
       initContainers:
       - name: initialize-dka-config
-        image: kubeaddons/addon-initializer:v0.0.5-alpha
+        image: kubeaddons/addon-initializer:dexk8sauthenticator-cm
         args: ["dexK8sAuthenticator"]

--- a/templates/dex-k8s-authenticator.yaml
+++ b/templates/dex-k8s-authenticator.yaml
@@ -58,5 +58,5 @@ spec:
           value: cGxhY2Vob2xkZXIK # b64 "placeholder" this will be updated by initcontainers
       initContainers:
       - name: initialize-dka-config
-        image: kubeaddons/addon-initializer:dexk8sauthenticator-cm
+        image: kubeaddons/addon-initializer:v0.0.6-alpha
         args: ["dexK8sAuthenticator"]


### PR DESCRIPTION
I still don't know when we are going to be tagging images, but this was the tag I tested with.
Built from https://github.com/mesosphere/kubeaddons-extrasteps/pull/7