### PR TITLE
localvolumeprovisioner: change the namespace to kube-system

### DIFF
--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -3,7 +3,7 @@ apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
 metadata:
   name: localvolumeprovisioner
-  namespace: kube-system
+  namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: localvolumeprovisioner
     kubeaddons.mesosphere.io/provides: storageclass
@@ -12,6 +12,7 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
+  namespace: kube-system 
   cloudProvider:
     - name: aws
       enabled: false

--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -23,4 +23,4 @@ spec:
   chartReference:
     chart: localvolumeprovisioner
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.2.2
+    version: 0.3.1

--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -3,7 +3,7 @@ apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
 metadata:
   name: localvolumeprovisioner
-  namespace: kubeaddons
+  namespace: kube-system
   labels:
     kubeaddons.mesosphere.io/name: localvolumeprovisioner
     kubeaddons.mesosphere.io/provides: storageclass


### PR DESCRIPTION
This is a proposal to overcome this issue https://github.com/kubernetes/kubernetes/issues/76308 when using priorityClassName: https://github.com/mesosphere/charts/blob/dev/stable/localvolumeprovisioner/values.yaml#L12

My intention is to treat the localvolumeprovisioner similarly to how it is treated another storage provisioner