### PR TITLE
Update dex version to latest image tag

### DIFF
--- a/templates/dex.yaml
+++ b/templates/dex.yaml
@@ -29,7 +29,7 @@ spec:
       # Temprarily we're going to use our custom built container. Documentation
       # for how to build a new version: https://github.com/mesosphere/dex/blob/v2.17.0-mesosphere/README.mesosphere.md
       image: mesosphere/dex
-      imageTag: v2.17.0-7-g2396-mesosphere
+      imageTag: v2.17.0-21-g4386-mesosphere
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
@natmegs Please verify this is the last tag you built last week.

I mistakenly gave the go ahead to merge https://github.com/mesosphere/kubeaddons-configs/pull/145, thinking the tag had already been updated.  I apologize for the churn.