### PR TITLE
Bump prometheus-operator chart to 5.10.4

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -32,7 +32,7 @@ spec:
   chartReference:
     chart: prometheus-operator
     repo: https://mesosphere.github.io/charts/staging
-    version: 5.10.1
+    version: 5.10.4
     values: |
       ---
       defaultRules:


### PR DESCRIPTION
Bump prometheus-operator chart version to 5.10.4. This bump includes: new Konvoy UI dashboard, a bug fix to get ES dashboard installed successfully, and typo fix in the mesosphere resources.