### PR TITLE
Bump prometheus-operator to 5.10.6

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -32,7 +32,7 @@ spec:
   chartReference:
     chart: prometheus-operator
     repo: https://mesosphere.github.io/charts/staging
-    version: 5.10.5
+    version: 5.10.6
     values: |
       ---
       defaultRules:


### PR DESCRIPTION
Contains updates from https://github.com/mesosphere/charts/pull/100