### PR TITLE
Enable velero service monitor

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -67,6 +67,8 @@ spec:
                 port: metrics
                 interval: 30s
         prometheusSpec:
+          serviceMonitorSelectorNilUsesHelmValues: false
+          serviceMonitorNamespaceSelector: {}
           additionalScrapeConfigs:
             - job_name: 'kubernetes-nodes-containerd'
               metrics_path: /v1/metrics

--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -67,6 +67,6 @@ spec:
       metrics:
         enabled: true
         # TODO: re-enable the serviceMonitor later, it doesn't work out of the box with the current stable velero chart (see DCOS-56470)
-        # serviceMonitor:
-        #   enabled: true
+        serviceMonitor:
+          enabled: true
       minioBackend: true


### PR DESCRIPTION
I read through some issues in the prometheus-operator helm chart and found [this thread](https://github.com/helm/charts/issues/13196) which explained how to get service monitors in other namespaces pulled in. I believe this effectively fixes https://jira.mesosphere.com/browse/DCOS-56470 as well.

![image](https://user-images.githubusercontent.com/5897740/62498812-61c7b980-b795-11e9-88c7-53627d003c54.png)
