### PR TITLE
Scrape velero monitoring prom endpoint

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -52,8 +52,11 @@ spec:
               matchNames:
                 - kubeaddons
                 - kommander
+                - velero
             endpoints:
               - port: metrics
+                interval: 30s
+              - port: monitoring
                 interval: 30s
           - name: kubeaddons-service-monitor-api-v1-metrics-prometheus
             selector:

--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -42,7 +42,7 @@ spec:
   chartReference:
     chart: velero
     repo: https://mesosphere.github.io/charts/staging
-    version: 2.2.1
+    version: 2.2.2
     values: |
       ---
       configuration:
@@ -66,7 +66,7 @@ spec:
           schedule: "0 0 * * *"
       metrics:
         enabled: true
-        # TODO: re-enable the serviceMonitor later, it doesn't work out of the box with the current stable velero chart (see DCOS-56470)
-        # serviceMonitor:
-        #   enabled: true
+        service:
+          labels:
+            servicemonitor.kubeaddons.mesosphere.io/path: "metrics"
       minioBackend: true


### PR DESCRIPTION
Adds service labels to velero to get its metrics scraped by prometheus. Depends on https://github.com/mesosphere/charts/pull/104