### PR TITLE
[DCOS-56671] prometheus-adapter: set resources

### DIFF
--- a/templates/prometheusadapter.yaml
+++ b/templates/prometheusadapter.yaml
@@ -28,6 +28,13 @@ spec:
       ---
       prometheus:
         url: http://prometheus-kubeaddons-prom-prometheus
+      resources:
+        limits:
+          cpu: 2000m
+           memory: 2000Mi
+        requests:
+           cpu: 1000m
+           memory: 1000Mi
       metricsRelistInterval: 30s
       rules:
         resource:


### PR DESCRIPTION

<img width="1420" alt="Screen Shot 2019-08-21 at 8 24 25 PM" src="https://user-images.githubusercontent.com/3602792/63457784-e97a1d00-c451-11e9-9c33-6a4f66122575.png">
related to: https://jira.mesosphere.com/browse/DCOS-56671