### PR TITLE
Expose keepalived metrics

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -118,6 +118,38 @@ spec:
               - source_labels: [__meta_kubernetes_namespace]
                 target_label: namespace
                 action: replace
+            - job_name: 'kubernetes-keepalived'
+              metrics_path: /snmp
+              params:
+                target: ["127.0.0.1:6161"]
+                module: ["keepalived"]
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              kubernetes_sd_configs:
+                - role: pod
+                  namespaces:
+                    names:
+                    - kube-system
+              relabel_configs:
+              - source_labels: [__meta_kubernetes_pod_container_port_protocol]
+                regex: TCP
+                action: keep
+              - source_labels: [__meta_kubernetes_pod_container_port_number]
+                regex: "6161"
+                action: keep
+              - source_labels: [__meta_kubernetes_pod_container_port_name]
+                target_label: endpoint
+                action: replace
+              - source_labels: [__meta_kubernetes_pod_node_name]
+                target_label: node
+                action: replace
+              - source_labels: [__meta_kubernetes_pod_name]
+                target_label: pod
+                action: replace
+              - source_labels: [__meta_kubernetes_namespace]
+                target_label: namespace
+                action: replace
           enableAdminAPI: true
           secrets:
             - etcd-certs


### PR DESCRIPTION
```
> {job="kubernetes-keepalived"}
scrape_duration_seconds{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0"}	0.071160588
scrape_samples_post_metric_relabeling{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0"}	24
scrape_samples_scraped{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0"}	24
snmp_scrape_duration_seconds{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0"}	0.022742245
snmp_scrape_pdus_returned{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0"}	22
snmp_scrape_walk_duration_seconds{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0"}	0.022078689
up{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0"}	1
vrrpInstanceAccept{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	0
vrrpInstanceAdvertisementsInt{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	1
vrrpInstanceAuthType{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	1
vrrpInstanceBasePriority{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	100
vrrpInstanceEffectivePriority{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	100
vrrpInstanceGarpDelay{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	1
vrrpInstanceInitialState{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	1
vrrpInstanceName{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1",vrrpInstanceName="lb-vips"}	1
vrrpInstanceNotifyExec{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	2
vrrpInstancePreempt{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	2
vrrpInstancePreemptDelay{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	0
vrrpInstancePrimaryInterface{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1",vrrpInstancePrimaryInterface="eth0"}	1
vrrpInstancePromoteSecondaries{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	2
vrrpInstanceSmtpAlert{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	2
vrrpInstanceState{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	2
vrrpInstanceTrackPrimaryIf{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	2
vrrpInstanceUseLinkbeat{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	2
vrrpInstanceVipsStatus{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	1
vrrpInstanceVirtualRouterId{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	220
vrrpInstanceVrrpVersion{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}	2
vrrpInstanceWantedState{endpoint="snmp-metrics",instance="172.17.0.3:6161",job="kubernetes-keepalived",namespace="kube-system",node="out-darwin-control-plane-0",pod="keepalived-out-darwin-control-plane-0",vrrpInstanceIndex="1"}
```