### PR TITLE
Export and scrape Kibana metrics

### DIFF
--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -40,12 +40,19 @@ spec:
         type: ClusterIP
         externalPort: 5601
         internalPort: 5601
+        labels:
+          servicemonitor.kubeaddons.mesosphere.io/path: "prometheus__metrics"
       resources:
         # need more cpu upon initialization, therefore burstable class
         limits:
           cpu: 1000m
         requests:
           cpu: 100m
+      plugins:
+        enabled: true
+        reset: true
+        values:
+          - kibana-prometheus-exporter,6.7.0,https://github.com/pjhampton/kibana-prometheus-exporter/releases/download/6.7.0/kibana-prometheus-exporter-6.7.0.zip
       extraContainers: |
         - name: initialize-kibana-index
           image: mesosphere/kubeaddons-addon-initializer:v0.0.4

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -72,6 +72,17 @@ spec:
               - path: /api/v1/metrics/prometheus
                 port: metrics
                 interval: 30s
+          - name: kubeaddons-service-monitor-prometheus-metrics
+            selector:
+              matchLabels:
+                servicemonitor.kubeaddons.mesosphere.io/path: "prometheus__metrics"
+            namespaceSelector:
+              matchNames:
+                - kubeaddons
+            endpoints:
+              - path: /_prometheus/metrics
+                targetPort: 5601
+                interval: 30s
         prometheusSpec:
           additionalScrapeConfigs:
             - job_name: 'kubernetes-nodes-containerd'


### PR DESCRIPTION
Adds the [kibana-prometheus-exporter](https://github.com/pjhampton/kibana-prometheus-exporter) plugin to kibana which exports metrics in prometheus format to `/_prometheus/metrics`, and adds the necessary service labels to get the metrics scraped by prometheus.

![image](https://user-images.githubusercontent.com/5897740/63986628-9a536e00-ca89-11e9-8b9b-555681666901.png)

![image](https://user-images.githubusercontent.com/5897740/63986636-a50e0300-ca89-11e9-90ea-fb05f418e8e1.png)
