### PR TITLE
[bug] Remove ingress controller dep from dex-k8s-auth

### DIFF
--- a/templates/dex-k8s-authenticator.yaml
+++ b/templates/dex-k8s-authenticator.yaml
@@ -19,7 +19,6 @@ spec:
       enabled: true
   requires:
     matchLabels:
-      kubeaddons.mesosphere.io/provides: ingresscontroller
       kubeaddons.mesosphere.io/name: dex
   chartReference:
     chart: dex-k8s-authenticator


### PR DESCRIPTION
The dependency setup for this Addon is currently broken. It intends to depend on two different addons, but currently the functionality is that it's depending on one Addon with two unrelated provisions. Dex already depends on the ingress controller, so we can remove that dependency at this level to simplify dependency management for this Addon.