### PR TITLE
Bump prometheus-operator to 5.10.9

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -32,7 +32,7 @@ spec:
   chartReference:
     chart: prometheus-operator
     repo: https://mesosphere.github.io/charts/staging
-    version: 5.10.8
+    version: 5.10.9
     values: |
       ---
       defaultRules:


### PR DESCRIPTION
Bump prometheus-operator to 5.10.9 to pull in new Kibana dashboard.