### PR TITLE
prometheusadapter: fix empty node metrics

### DIFF
--- a/templates/prometheusadapter.yaml
+++ b/templates/prometheusadapter.yaml
@@ -43,7 +43,7 @@ spec:
             nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[1m])) by (<<.GroupBy>>)
             resources:
               overrides:
-                instance:
+                node:
                  resource: node
                 namespace:
                  resource: namespace
@@ -55,7 +55,7 @@ spec:
             nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
             resources:
               overrides:
-                instance:
+                node:
                  resource: node
                 namespace:
                  resource: namespace


### PR DESCRIPTION
The query was indeed returning an empty result because we were replacing a valid label name `node` by `instance` that it didn't exist

```
kubectl get --raw "/apis/metrics.k8s.io/v1beta1/nodes"  --kubeconfig=admin.conf
{"kind":"NodeMetricsList","apiVersion":"metrics.k8s.io/v1beta1","metadata":{"selfLink":"/apis/metrics.k8s.io/v1beta1/nodes"},"items":[{"metadata":{"name":"ip-10-0-193-120.us-west-2.compute.internal","selfLink":"/apis/metrics.k8s.io/v1beta1/nodes/ip-10-0-193-120.us-west-2.compute.internal","creationTimestamp":"2019-09-02T12:31:07Z"},"timestamp":"2019-09-02T12:31:07Z","window":"1m0s","usage":{"cpu":"208m","memory":"2263684Ki"}},{"metadata":{"name":"ip-10-0-194-69.us-west-2.compute.internal","selfLink":"/apis/metrics.k8s.io/v1beta1/nodes/ip-10-0-194-69.us-west-2.compute.internal","creationTimestamp":"2019-09-02T12:31:07Z"},"timestamp":"2019-09-02T12:31:07Z","window":"1m0s","usage":{"cpu":"185m","memory":"2376700Ki"}},{"metadata":{"name":"ip-10-0-195-48.us-west-2.compute.internal","selfLink":"/apis/metrics.k8s.io/v1beta1/nodes/ip-10-0-195-48.us-west-2.compute.internal","creationTimestamp":"2019-09-02T12:31:07Z"},"timestamp":"2019-09-02T12:31:07Z","window":"1m0s","usage":{"cpu":"178m","memory":"2174256Ki"}},{"metadata":{"name":"ip-10-0-131-55.us-west-2.compute.internal","selfLink":"/apis/metrics.k8s.io/v1beta1/nodes/ip-10-0-131-55.us-west-2.compute.internal","creationTimestamp":"2019-09-02T12:31:07Z"},"timestamp":"2019-09-02T12:31:07Z","window":"1m0s","usage":{"cpu":"664m","memory":"6294924Ki"}},{"metadata":{"name":"ip-10-0-131-121.us-west-2.compute.internal","selfLink":"/apis/metrics.k8s.io/v1beta1/nodes/ip-10-0-131-121.us-west-2.compute.internal","creationTimestamp":"2019-09-02T12:31:07Z"},"timestamp":"2019-09-02T12:31:07Z","window":"1m0s","usage":{"cpu":"328m","memory":"7681900Ki"}},{"metadata":{"name":"ip-10-0-131-229.us-west-2.compute.internal","selfLink":"/apis/metrics.k8s.io/v1beta1/nodes/ip-10-0-131-229.us-west-2.compute.internal","creationTimestamp":"2019-09-02T12:31:07Z"},"timestamp":"2019-09-02T12:31:07Z","window":"1m0s","usage":{"cpu":"440m","memory":"4380768Ki"}},{"metadata":{"name":"ip-10-0-130-122.us-west-2.compute.internal","selfLink":"/apis/metrics.k8s.io/v1beta1/nodes/ip-10-0-130-122.us-west-2.compute.internal","creationTimestamp":"2019-09-02T12:31:07Z"},"timestamp":"2019-09-02T12:31:07Z","window":"1m0s","usage":{"cpu":"373m","memory":"10391884Ki"}}]}
```
This also fixes another bug related to `kubectl top nodes`

```
➜  out-darwin git:(hectorj2f/image_cli_upgrade) ✗ kubectl top nodes --kubeconfig=admin.conf
NAME                                         CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%
ip-10-0-130-122.us-west-2.compute.internal   370m         9%     10189Mi         65%
ip-10-0-131-121.us-west-2.compute.internal   315m         7%     7548Mi          48%
ip-10-0-131-229.us-west-2.compute.internal   216m         5%     4280Mi          27%
ip-10-0-131-55.us-west-2.compute.internal    666m         16%    6117Mi          39%
ip-10-0-193-120.us-west-2.compute.internal   180m         9%     2212Mi          29%
ip-10-0-194-69.us-west-2.compute.internal    183m         9%     2317Mi          30%
ip-10-0-195-48.us-west-2.compute.internal    170m         8%     2116Mi          27%
```