### PR TITLE
Change how addons require a default StorageClass

### DIFF
--- a/templates/elasticsearch.yaml
+++ b/templates/elasticsearch.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: elasticsearch
+    # TODO: we're temporarily supporting dependency on an existing default storage class
+    # on the cluster, this hack will trigger re-queue on Addons until one exists.
+    kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: true
   annotations:
     appversion.kubeaddons.mesosphere.io/elasticsearch: "6.7.0"
 spec:
@@ -18,9 +21,6 @@ spec:
       enabled: false
     - name: none
       enabled: true
-  requires:
-    matchLabels:
-      kubeaddons.mesosphere.io/provides: defaultstorageclass
   chartReference:
     chart: stable/elasticsearch
     version: 1.26.2

--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: kommander
+    # TODO: we're temporarily supporting dependency on an existing default storage class
+    # on the cluster, this hack will trigger re-queue on Addons until one exists.
+    kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: true
   annotations:
     appversion.kubeaddons.mesosphere.io/kommander: "1.50.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander
@@ -24,6 +27,3 @@ spec:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
     version: 0.1.21
-  requires:
-    matchLabels:
-      kubeaddons.mesosphere.io/provides: defaultstorageclass

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: prometheus
+    # TODO: we're temporarily supporting dependency on an existing default storage class
+    # on the cluster, this hack will trigger re-queue on Addons until one exists.
+    kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: true
   annotations:
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.31.1"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.9.1"
@@ -26,9 +29,6 @@ spec:
       enabled: false
     - name: none
       enabled: true
-  requires:
-    matchLabels:
-      kubeaddons.mesosphere.io/provides: defaultstorageclass
   chartReference:
     chart: prometheus-operator
     repo: https://mesosphere.github.io/charts/staging

--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: traefik
     kubeaddons.mesosphere.io/provides: ingresscontroller
+    # TODO: we're temporarily supporting dependency on an existing default storage class
+    # on the cluster, this hack will trigger re-queue on Addons until one exists.
+    kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: true
   annotations:
     appversion.kubeaddons.mesosphere.io/traefik: "1.68.4"
     endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
@@ -13,9 +16,6 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
-  requires:
-    matchLabels:
-      kubeaddons.mesosphere.io/provides: defaultstorageclass
   chartReference:
     chart: traefik
     repo: https://mesosphere.github.io/charts/staging

--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -27,13 +27,13 @@ metadata:
   namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: velero
+    # TODO: we're temporarily supporting dependency on an existing default storage class
+    # on the cluster, this hack will trigger re-queue on Addons until one exists.
+    kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: true
 spec:
   namespace: velero
   kubernetes:
     minSupportedVersion: v1.15.0
-  requires:
-    matchLabels:
-      kubeaddons.mesosphere.io/provides: defaultstorageclass
   cloudProvider:
     - name: aws
       enabled: true


### PR DESCRIPTION
This PR removes the search for labels to find a provided default storage class, and instead simply flags whether it needs a default storage class as part of the requirements.

This will help kubeaddons to better support a wider range of clusters, and provide end users more options to determine where the storage for their addons comes from.