### PR TITLE
use cloudProvider values

### DIFF
--- a/templates/awsebsprovisioner.yaml
+++ b/templates/awsebsprovisioner.yaml
@@ -15,6 +15,9 @@ spec:
   cloudProvider:
     - name: aws
       enabled: false
+      values: |
+        storageclass:
+          isDefault: false
   chartReference:
     chart: awsebsprovisioner
     repo: https://mesosphere.github.io/charts/stable

--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -16,6 +16,9 @@ spec:
   cloudProvider:
     - name: aws
       enabled: false
+      values: |
+        storageclass:
+          isDefault: false
     - name: docker
       enabled: true
     - name: none

--- a/templates/metallb.yaml
+++ b/templates/metallb.yaml
@@ -14,8 +14,22 @@ spec:
   cloudProvider:
     - name: docker
       enabled: true
+      values: |
+        configInline:
+          address-pools:
+          - name: default
+            protocol: layer2
+            addresses:
+            - 172.17.1.200-172.17.1.250
     - name: none
       enabled: true
+      values: |
+        configInline:
+          address-pools:
+          - name: default
+            protocol: layer2
+            # configure addresses for your network
+            addresses: []
   chartReference:
     chart: stable/metallb
     version: 0.9.5


### PR DESCRIPTION
kubeaddons now has the ability to add `values` per cloud provider. These values will be used to create the addon configs that are user-facing with preset values based on the provider selected.