### PR TITLE
nvidia: Added nvidia kubeaddon config

### DIFF
--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -15,7 +15,7 @@ spec:
   namespace: kube-system
   cloudProvider:
     - name: aws
-      enabled: true
+      enabled: false
     - name: docker
       enabled: false
     - name: none

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -24,3 +24,29 @@ spec:
     chart: nvidia
     repo: https://mesosphere.github.io/charts/staging
     version: 0.1.0
+    values: |
+      ---
+      nvidia-driver:
+        resources:
+          limits:
+             cpu: 2000m
+             memory: 6144Mi
+          requests:
+             cpu: 200m
+             memory: 256Mi
+        nodeSelector:
+          konvoy.mesosphere.com/gpu-provider: NVIDIA
+      nvidia-device-plugin:
+        resources:
+          limits:
+             cpu: 200m
+             memory: 128Mi
+          requests:
+             cpu: 100m
+             memory: 128Mi
+        nodeSelector:
+          konvoy.mesosphere.com/gpu-provider: NVIDIA
+        initContainers:
+        - name: init-wait
+          image: busybox
+          command: ['sh', '-c', 'sleep 90']

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
-  namespace: kube-system 
+  namespace: kube-system
   cloudProvider:
     - name: aws
       enabled: true

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kubeaddons.mesosphere.io/v1alpha1
+kind: Addon
+metadata:
+  name: nvidia
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: nvidia
+    kubeaddons.mesosphere.io/provides: nvidia
+  annotations:
+    appversion.kubeaddons.mesosphere.io/nvidia: "0.1"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.0
+  namespace: kube-system 
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: docker
+      enabled: false
+    - name: none
+      enabled: false
+  chartReference:
+    chart: nvidia
+    repo: https://mesosphere.github.io/charts/staging
+    version: 0.1.0


### PR DESCRIPTION
This addon includes nvidia drive container and device plugin.

Corresponding to https://github.com/mesosphere/charts/pull/120