### PR TITLE
chore: change localvolumeprovisioner defaults for aws

### DIFF
--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -17,8 +17,17 @@ spec:
     - name: aws
       enabled: false
       values: |
-        storageclass:
-          isDefault: false
+        # Multiple storage classes can be defined here. This allows to, e.g.,
+        # distinguish between different disk types.
+        # For each entry a storage class '$name' and
+        # a host folder '/mnt/$dirName' will be created. Volumes mounted to this
+        # folder are made available in the storage class.
+        storageclasses:
+          - name: localvolumeprovisioner
+            dirName: disks
+            isDefault: false
+            reclaimPolicy: Delete
+            volumeBindingMode: WaitForFirstConsumer
     - name: docker
       enabled: true
     - name: none


### PR DESCRIPTION
localvolumeprovisioner uses different syntax from the
other storage class charts. Since the entire list item
would be replaced, quote the whole thing here, resetting
isDefault and include the help text.