### PR TITLE
Bump alertmanager version to v0.17.0

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -184,6 +184,8 @@ spec:
               memory: 1000Mi
       alertmanager:
         alertmanagerSpec:
+          image:
+            tag: v0.17.0
           resources:
             limits:
               cpu: 100m


### PR DESCRIPTION
In preparation for running [Karma](https://github.com/helm/charts/tree/master/stable/karma) as a central alerting dashboard in Kommander, we need to bump Konvoy Alertmanagers up to a version > 0.16.x in order to be compatible with Karma (it is currently defaulted to v0.16.2 on our version of prometheus-operator). See https://github.com/prymitive/karma/issues/115 for more details