### PR TITLE
Enable Thanos sidecar

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -9,7 +9,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.31.1"
+    appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.29.0"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.9.1"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.16.2"
     appversion.kubeaddons.mesosphere.io/grafana: "6.1.6"

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -84,6 +84,9 @@ spec:
                 targetPort: 5601
                 interval: 30s
         prometheusSpec:
+          thanos:
+            baseImage: thanosio/thanos
+            version: v0.4.0
           additionalScrapeConfigs:
             - job_name: 'kubernetes-nodes-containerd'
               metrics_path: /v1/metrics


### PR DESCRIPTION
Enables the Thanos sidecars on prometheus-operator. This is in preparation for a Thanos Querier running in Kommander that will collect all Prometheus metrics through the sidecar on all the Konvoy clusters it is connected to. In the future, we will likely also utilize the sidecars for storage backups.

It looks like we are on v0.29.0 of prometheus-operator, unless I'm mistaken (referencing https://github.com/mesosphere/charts/blob/dev/staging/prometheus-operator/Chart.yaml#L2). I've fixed the label to reflect the correct version here as well. Thanos >0.4 is incompatible with prometheus-operator versions older than 0.31 (see https://github.com/coreos/prometheus-operator/issues/2635), which is why I've set the Thanos version to 0.4. If we upgrade prometheus-operator to >=0.31, we'll be able to upgrade Thanos as well.