### PR TITLE
Add helm values yaml metadata to some addons

### DIFF
--- a/templates/awsebscsiprovisioner.yaml
+++ b/templates/awsebscsiprovisioner.yaml
@@ -9,6 +9,7 @@ metadata:
     kubeaddons.mesosphere.io/provides: storageclass
   annotations:
     appversion.kubeaddons.mesosphere.io/awsebscsiprovisioner: "0.4.0"
+    values.chart.helm.kubeaddons.mesosphere.io/awsebscsiprovisioner: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/awsebscsiprovisioner/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/awsebsprovisioner.yaml
+++ b/templates/awsebsprovisioner.yaml
@@ -9,6 +9,7 @@ metadata:
     kubeaddons.mesosphere.io/provides: storageclass
   annotations:
     appversion.kubeaddons.mesosphere.io/awsebsprovisioner: "1.0"
+    values.chart.helm.kubeaddons.mesosphere.io/awsebsprovisioner: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/awsebsprovisioner/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/cert-manager.yaml
+++ b/templates/cert-manager.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     appversion.kubeaddons.mesosphere.io/cert-manager: "0.10.0"
     docs.kubeaddons.mesosphere.io/cert-manager: "https://docs.cert-manager.io/en/release-0.10/"
+    values.chart.helm.kubeaddons.mesosphere.io/cert-manager: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/staging/cert-manager-setup/values.yaml"
 spec:
   namespace: cert-manager
   kubernetes:

--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -10,6 +10,7 @@ metadata:
     appversion.kubeaddons.mesosphere.io/dashboard: "1.10.1"
     endpoint.kubeaddons.mesosphere.io/dashboard: "/ops/portal/kubernetes/"
     docs.kubeaddons.mesosphere.io/dashboard: "https://github.com/kubernetes/dashboard/blob/master/README.md"
+    values.chart.helm.kubeaddons.mesosphere.io/dashboard: "https://raw.githubusercontent.com/helm/charts/5e7b6640dd6b566bb136fffaca1b54da392d3074/stable/kubernetes-dashboard/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/dex-k8s-authenticator.yaml
+++ b/templates/dex-k8s-authenticator.yaml
@@ -7,6 +7,7 @@ metadata:
     kubeaddons.mesosphere.io/name: dex-k8s-authenticator
   annotations:
     appversion.kubeaddons.mesosphere.io/dex-k8s-authenticator: "v1.1.0"
+    values.chart.helm.kubeaddons.mesosphere.io/dex-k8s-authenticator: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/staging/dex-k8s-authenticator/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/dex.yaml
+++ b/templates/dex.yaml
@@ -7,6 +7,7 @@ metadata:
     kubeaddons.mesosphere.io/name: dex
   annotations:
     appversion.kubeaddons.mesosphere.io/dex: "2.16.0"
+    values.chart.helm.kubeaddons.mesosphere.io/dex: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/dex/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/elasticsearch.yaml
+++ b/templates/elasticsearch.yaml
@@ -11,6 +11,7 @@ metadata:
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
     appversion.kubeaddons.mesosphere.io/elasticsearch: "6.7.0"
+    values.chart.helm.kubeaddons.mesosphere.io/elasticsearch: "https://raw.githubusercontent.com/helm/charts/6bfbc8018cd4440637b07c7559d5812e4d9db34d/stable/elasticsearch/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/elasticsearchexporter.yaml
+++ b/templates/elasticsearchexporter.yaml
@@ -8,6 +8,7 @@ metadata:
     kubeaddons.mesosphere.io/name: elasticsearchexporter
   annotations:
     appversion.kubeaddons.mesosphere.io/elasticsearchexporter: "1.0.2"
+    values.chart.helm.kubeaddons.mesosphere.io/elasticsearchexporter: "https://raw.githubusercontent.com/helm/charts/08fc376647d43169743dcf04f1e88a2aec9e5f3d/stable/elasticsearch-exporter/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/fluentbit.yaml
+++ b/templates/fluentbit.yaml
@@ -8,6 +8,7 @@ metadata:
     kubeaddons.mesosphere.io/name: fluentbit
   annotations:
     appversion.kubeaddons.mesosphere.io/fluentbit: "1.2.1"
+    values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/helm/charts/f9efc8de7dcd6f93ebacc4b321d01a5aa819cdaa/stable/fluent-bit/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -10,6 +10,7 @@ metadata:
     appversion.kubeaddons.mesosphere.io/kibana: "6.7.0"
     endpoint.kubeaddons.mesosphere.io/kibana: "/ops/portal/kibana"
     docs.kubeaddons.mesosphere.io/kibana: "https://www.elastic.co/guide/en/kibana/6.7/index.html"
+    values.chart.helm.kubeaddons.mesosphere.io/kibana: "https://raw.githubusercontent.com/helm/charts/09004fa332094693e2e5fcffe474622ba15491ae/stable/kibana/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -12,6 +12,7 @@ metadata:
   annotations:
     appversion.kubeaddons.mesosphere.io/kommander: "1.50.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander
+    values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/kommander/values.yaml"
 spec:
   namespace: kommander
   kubernetes:

--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -9,6 +9,7 @@ metadata:
     kubeaddons.mesosphere.io/provides: storageclass
   annotations:
     appversion.kubeaddons.mesosphere.io/localvolumeprovisioner: "1.0"
+    values.chart.helm.kubeaddons.mesosphere.io/localvolumeprovisioner: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/localvolumeprovisioner/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/metallb.yaml
+++ b/templates/metallb.yaml
@@ -8,6 +8,7 @@ metadata:
     kubeaddons.mesosphere.io/provides: loadbalancer
   annotations:
     appversion.kubeaddons.mesosphere.io/metallb: "0.7.3"
+    values.chart.helm.kubeaddons.mesosphere.io/metallb: "https://raw.githubusercontent.com/helm/charts/b0f9cb2d7af822e0031f632f2faa0cbb53167770/stable/metallb/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/opsportal.yaml
+++ b/templates/opsportal.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     appversion.kubeaddons.mesosphere.io/opsportal: "1.0.0"
     endpoint.kubeaddons.mesosphere.io/opsportal: /ops/portal/
+    values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/opsportal/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -19,6 +19,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/prometheus: "https://prometheus.io/docs/introduction/overview/"
     docs.kubeaddons.mesosphere.io/grafana: "https://grafana.com/docs/"
     docs.kubeaddons.mesosphere.io/alertmanager: "https://prometheus.io/docs/alerting/alertmanager/"
+    values.chart.helm.kubeaddons.mesosphere.io/prometheus: "https://raw.githubusercontent.com/helm/charts/0459eb2bdade42a88a44ee115184ba584bd3131c/stable/prometheus-operator/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/prometheusadapter.yaml
+++ b/templates/prometheusadapter.yaml
@@ -8,6 +8,7 @@ metadata:
     kubeaddons.mesosphere.io/name: prometheusadapter
   annotations:
     appversion.kubeaddons.mesosphere.io/prometheusadapter: "0.5.0"
+    values.chart.helm.kubeaddons.mesosphere.io/prometheusadapter: "https://raw.githubusercontent.com/helm/charts/db62a6c595bbd9904014083edd0faa14de4096b2/stable/prometheus-adapter/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -8,7 +8,8 @@ spec:
     minSupportedVersion: v1.15.0
   requires:
     matchLabels:
-      kubeaddons.mesosphere.io/name: dex    
+      kubeaddons.mesosphere.io/name: dex
+      values.chart.helm.kubeaddons.mesosphere.io/traefik-forward-auth: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/staging/traefik-forward-auth/values.yaml"
   chartReference:
     chart: traefik-forward-auth
     repo: https://mesosphere.github.io/charts/staging

--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -13,6 +13,7 @@ metadata:
     appversion.kubeaddons.mesosphere.io/traefik: "1.68.4"
     endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
     docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/v1.7"
+    values.chart.helm.kubeaddons.mesosphere.io/traefik: "https://raw.githubusercontent.com/helm/charts/c7e31361a28a10e30b4143b73439080d5e9f7d8b/stable/traefik/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -30,6 +30,8 @@ metadata:
     # TODO: we're temporarily supporting dependency on an existing default storage class
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
+  annotations:
+    values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/helm/charts/39524419882dcf3d1a053711ac242c280923a094/stable/velero/values.yaml"
 spec:
   namespace: velero
   kubernetes:


### PR DESCRIPTION
This PR adds some links to the annotations of several addons which indicate that the addon has default helm chart values and links to a view of those defaults.

Resolves [DCOS-59121](https://jira.mesosphere.com/browse/DCOS-59121)