### PR TITLE
awsebscsiprovisioner: bump to 0.3.1

### DIFF
--- a/templates/awsebscsiprovisioner.yaml
+++ b/templates/awsebscsiprovisioner.yaml
@@ -20,7 +20,7 @@ spec:
   chartReference:
     chart: awsebscsiprovisioner
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.3.0
+    version: 0.3.1
     values: |
       ---
       resizer:


### PR DESCRIPTION
Fixes `failed to create VolumeSnapshotResource:` error and adds support for passing `env` vars.