### PR TITLE
Remove Kommander DSC Requirement

### DIFF
--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -6,9 +6,6 @@ metadata:
   namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: kommander
-    # TODO: we're temporarily supporting dependency on an existing default storage class
-    # on the cluster, this hack will trigger re-queue on Addons until one exists.
-    kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
     appversion.kubeaddons.mesosphere.io/kommander: "1.50.0"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander


### PR DESCRIPTION
Removes an accidentally placed requirement for DSC to exist for Kommander Addon.

Resolves [DCOS-58414](https://jira.mesosphere.com/browse/DCOS-58414)