### PR TITLE
dex: requires cert-manager

### DIFF
--- a/templates/dex.yaml
+++ b/templates/dex.yaml
@@ -22,7 +22,6 @@ spec:
     matchLabels:
       kubeaddons.mesosphere.io/provides: ingresscontroller
       kubeaddons.mesosphere.io/name: cert-manager
-      values.chart.helm.kubeaddons.mesosphere.io/cert-manager-setup: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/staging/cert-manager-setup/values.yaml"
   chartReference:
     chart: dex
     repo: https://mesosphere.github.io/charts/stable

--- a/templates/dex.yaml
+++ b/templates/dex.yaml
@@ -21,7 +21,6 @@ spec:
   requires:
     matchLabels:
       kubeaddons.mesosphere.io/provides: ingresscontroller
-      kubeaddons.mesosphere.io/name: cert-manager
   chartReference:
     chart: dex
     repo: https://mesosphere.github.io/charts/stable

--- a/templates/dex.yaml
+++ b/templates/dex.yaml
@@ -21,6 +21,8 @@ spec:
   requires:
     matchLabels:
       kubeaddons.mesosphere.io/provides: ingresscontroller
+      kubeaddons.mesosphere.io/name: cert-manager
+      values.chart.helm.kubeaddons.mesosphere.io/cert-manager-setup: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/staging/cert-manager-setup/values.yaml"
   chartReference:
     chart: dex
     repo: https://mesosphere.github.io/charts/stable

--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -9,7 +9,6 @@ spec:
   requires:
     matchLabels:
       kubeaddons.mesosphere.io/name: dex
-      values.chart.helm.kubeaddons.mesosphere.io/traefik-forward-auth: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/staging/traefik-forward-auth/values.yaml"
   chartReference:
     chart: traefik-forward-auth
     repo: https://mesosphere.github.io/charts/staging

--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -17,6 +17,9 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
+  requires:
+    matchLabels:
+      kubeaddons.mesosphere.io/name: cert-manager    
   chartReference:
     chart: traefik
     repo: https://mesosphere.github.io/charts/staging


### PR DESCRIPTION
We need to include cert-manager in the dependencies of dex, so it gets installed before.