### PR TITLE
Update to traefik-forward-auth 1.0.4

### DIFF
--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -18,7 +18,7 @@ spec:
       replicaCount: 1
       image:
         repository: mesosphere/traefik-forward-auth
-        tag: 1.0.2
+        tag: 1.0.4
         pullPolicy: IfNotPresent
       resources:
         requests:


### PR DESCRIPTION
- remove additional slash from redirect URI
- redirect clients to specific host to ensure correct cookies

See https://github.com/mesosphere/konvoy/pull/845 for tests