### PR TITLE
velero: bump version to support minio service annotations

### DIFF
--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -44,7 +44,7 @@ spec:
   chartReference:
     chart: velero
     repo: https://mesosphere.github.io/charts/staging
-    version: 2.2.4
+    version: 2.2.5
     values: |
       ---
       configuration:


### PR DESCRIPTION
Depends on https://github.com/mesosphere/charts/pull/159

Needed to support https://github.com/mesosphere/konvoy/pull/851 and be able to specify an internal ELB for velero.