### PR TITLE
dex: bump to version 1.6.4

### DIFF
--- a/templates/dex.yaml
+++ b/templates/dex.yaml
@@ -24,7 +24,7 @@ spec:
   chartReference:
     chart: dex
     repo: https://mesosphere.github.io/charts/stable
-    version: 1.6.3
+    version: 1.6.4
     values: |
       ---
       # Temprarily we're going to use our custom built container. Documentation


### PR DESCRIPTION
Bump the dex chart version to 1.6.4. This includes the dex-controller
subchart for declarative management.

(cherry picked from commit 8f84e028594b6dfdcaf9e1658c0ac294eda4e7eb)