### PR TITLE
cert-manager: bump to 0.1.5

### DIFF
--- a/templates/cert-manager.yaml
+++ b/templates/cert-manager.yaml
@@ -23,7 +23,7 @@ spec:
   chartReference:
     chart: cert-manager-setup
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.1.4
+    version: 0.1.5
     values: |
       ---
       clusterissuer:


### PR DESCRIPTION
The new version fixes the upgrade issue due to hook resources.

(cherry picked from commit 88ce38966d0a6692295c700c14dab522f8909c20)