### PR TITLE
velero: bump version to support minio service annotations

### DIFF
--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -44,7 +44,7 @@ spec:
   chartReference:
     chart: velero
     repo: https://mesosphere.github.io/charts/staging
-    version: 2.2.4
+    version: 2.2.5
     values: |
       ---
       configuration:


### PR DESCRIPTION
Bringing in the changes from https://github.com/mesosphere/kubeaddons-configs/pull/241, adding ability to pass annotations to the dex service and create an internal ELB.