### PR TITLE
Bump kube-oidc-proxy chart version

### DIFF
--- a/templates/kube-oidc-proxy.yaml
+++ b/templates/kube-oidc-proxy.yaml
@@ -24,7 +24,7 @@ spec:
   chartReference:
     chart: kube-oidc-proxy
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.1.3
+    version: 0.1.4
     values: |
       ---
       image:


### PR DESCRIPTION
deps: https://github.com/mesosphere/charts/pull/172