### PR TITLE
templates: update nvidia properties

### DIFF
--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -9,16 +9,13 @@ metadata:
     kubeaddons.mesosphere.io/provides: nvidia
   annotations:
     appversion.kubeaddons.mesosphere.io/nvidia: "0.1"
+    values.chart.helm.kubeaddons.mesosphere.io/nvidia: "https://raw.githubusercontent.com/mesosphere/charts/869a26a8d4061d5b407cd260eac2eee9149f2823/staging/nvidia/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
   namespace: kube-system
   cloudProvider:
     - name: aws
-      enabled: false
-    - name: docker
-      enabled: false
-    - name: none
       enabled: false
   chartReference:
     chart: nvidia

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -17,6 +17,8 @@ spec:
   cloudProvider:
     - name: aws
       enabled: false
+    - name: none
+      enabled: false      
   chartReference:
     chart: nvidia
     repo: https://mesosphere.github.io/charts/staging

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -18,7 +18,7 @@ spec:
     - name: aws
       enabled: false
     - name: none
-      enabled: false      
+      enabled: false
   chartReference:
     chart: nvidia
     repo: https://mesosphere.github.io/charts/staging


### PR DESCRIPTION
I updated the nvidia properties accordingly to the new changes in the addons.

With 
```
name: aws
      enabled: false
```
we force users to set `true` whenever they want to run the `gpu`.

With this change https://github.com/mesosphere/kubeaddons-configs/compare/hectorj2f/enable_nvidia?expand=1#diff-48e90cb482008adf2d74147274088c73L19, the addon won't appear in the list of addons to be installed by default with these providers.