### PR TITLE
Remove namespace from spec on all addons

### DIFF
--- a/templates/awsebscsiprovisioner.yaml
+++ b/templates/awsebscsiprovisioner.yaml
@@ -3,7 +3,7 @@ apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
 metadata:
   name: awsebscsiprovisioner
-  namespace: kubeaddons
+  namespace: kube-system
   labels:
     kubeaddons.mesosphere.io/name: awsebscsiprovisioner
     kubeaddons.mesosphere.io/provides: storageclass
@@ -13,7 +13,6 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
-  namespace: kube-system
   cloudProvider:
     - name: aws
       enabled: true

--- a/templates/cert-manager.yaml
+++ b/templates/cert-manager.yaml
@@ -2,7 +2,7 @@ apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
 metadata:
   name: cert-manager
-  namespace: kubeaddons
+  namespace: cert-manager
   labels:
     kubeaddons.mesosphere.io/name: cert-manager
   annotations:
@@ -10,7 +10,6 @@ metadata:
     docs.kubeaddons.mesosphere.io/cert-manager: "https://docs.cert-manager.io/en/release-0.10/"
     values.chart.helm.kubeaddons.mesosphere.io/cert-manager: "https://raw.githubusercontent.com/mesosphere/charts/1b68b80a4384946575952fe095ce46510e5badad/staging/cert-manager-setup/values.yaml"
 spec:
-  namespace: cert-manager
   kubernetes:
     minSupportedVersion: v1.15.0
   cloudProvider:

--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -3,7 +3,7 @@ apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
 metadata:
   name: dashboard
-  namespace: kubeaddons
+  namespace: kube-system
   labels:
     kubeaddons.mesosphere.io/name: dashboard
   annotations:
@@ -14,7 +14,6 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
-  namespace: kube-system
   chartReference:
     chart: stable/kubernetes-dashboard
     version: 1.5.2

--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -3,7 +3,7 @@ apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
 metadata:
   name: kommander
-  namespace: kubeaddons
+  namespace: kommander
   labels:
     kubeaddons.mesosphere.io/name: kommander
     # TODO: we're temporarily supporting dependency on an existing default storage class
@@ -14,7 +14,6 @@ metadata:
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander
     values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/kommander/values.yaml"
 spec:
-  namespace: kommander
   kubernetes:
     minSupportedVersion: v1.15.0
   cloudProvider:

--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -3,7 +3,7 @@ apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
 metadata:
   name: localvolumeprovisioner
-  namespace: kubeaddons
+  namespace: kube-system
   labels:
     kubeaddons.mesosphere.io/name: localvolumeprovisioner
     kubeaddons.mesosphere.io/provides: storageclass
@@ -13,7 +13,6 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
-  namespace: kube-system 
   cloudProvider:
     - name: aws
       enabled: false

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -3,7 +3,7 @@ apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
 metadata:
   name: nvidia
-  namespace: kubeaddons
+  namespace: kube-system
   labels:
     kubeaddons.mesosphere.io/name: nvidia
     kubeaddons.mesosphere.io/provides: nvidia
@@ -12,7 +12,6 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
-  namespace: kube-system
   cloudProvider:
     - name: aws
       enabled: false

--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -24,7 +24,7 @@ apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
 metadata:
   name: velero
-  namespace: kubeaddons
+  namespace: velero
   labels:
     kubeaddons.mesosphere.io/name: velero
     # TODO: we're temporarily supporting dependency on an existing default storage class
@@ -33,7 +33,6 @@ metadata:
   annotations:
     values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/helm/charts/39524419882dcf3d1a053711ac242c280923a094/stable/velero/values.yaml"
 spec:
-  namespace: velero
   kubernetes:
     minSupportedVersion: v1.15.0
   cloudProvider:


### PR DESCRIPTION
Going forward the spec namespace field is no longer supported and addons will be deployed into the actual namespace that the Addon resource itself is in.