### PR TITLE
DCOS-59577 Add gatekeeper to kubeaddon configs

### DIFF
--- a/templates/gatekeeper.yaml
+++ b/templates/gatekeeper.yaml
@@ -1,0 +1,40 @@
+apiVersion: kubeaddons.mesosphere.io/v1alpha1
+kind: Addon
+metadata:
+  name: gatekeeper
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: gatekeeper
+  annotations:
+    appversion.kubeaddons.mesosphere.io/gatekeeper: "3.0.4-beta.1"
+    docs.kubeaddons.mesosphere.io/gatekeeper: "https://github.com/open-policy-agent/gatekeeper/blob/master/README.md"
+    values.chart.helm.kubeaddons.mesosphere.io/gatekeeper: "https://raw.githubusercontent.com/mesosphere/charts/f52ab9415b53aee946ff8e55a60b50be193b7ea7/staging/gatekeeper/values.yaml"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.0
+  requires:
+    matchLabels:
+      kubeaddons.mesosphere.io/name: cert-manager
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  chartReference:
+    chart: gatekeeper
+    repo: https://mesosphere.github.io/charts/staging
+    version: 0.1.0
+    values: |
+      ---
+      image:
+        tag: v3.0.4-beta.1
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 500Mi
+        requests:
+          cpu: 200m
+          memory: 300Mi
+


### PR DESCRIPTION
Gatekeeper: https://github.com/open-policy-agent/gatekeeper
Helm chart: https://github.com/mesosphere/charts/tree/dev/staging/gatekeeper

Added gatekeeper Addon to `kubeaddons-config` and tested if the new addon is installed automatically by Konvoy.

```
STAGE [Deploying Enabled Addons]
opsportal                                                              [OK]
traefik-forward-auth                                                   [OK]
traefik                                                                [OK]
dashboard                                                              [OK]
elasticsearchexporter                                                  [OK]
kommander                                                              [OK]
konvoyconfig                                                           [OK]
fluentbit                                                              [OK]
kibana                                                                 [OK]
prometheus                                                             [OK]
prometheusadapter                                                      [OK]
awsebscsiprovisioner                                                   [OK]
cert-manager                                                           [OK]
dex                                                                    [OK]
elasticsearch                                                          [OK]
dex-k8s-authenticator                                                  [OK]
velero                                                                 [OK]
gatekeeper                                                             [OK]
kube-oidc-proxy                                                        [OK]
```

Test if policy is enforced as expected (https://docs.d2iq.com/ksphere/konvoy/latest/tutorials/gatekeeper/)

1. Define the ConstraintTemplate for host path volume policy
```
$ kubectl -n kubeaddons apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/library/pod-security-policy/host-filesystem/template.yaml
constrainttemplate.templates.gatekeeper.sh/k8spsphostfilesystem created
```
2. Define the Constraint to only allow `/foo` to be mounted as a host path volume.
```
$ cat <<EOF | kubectl apply -n kubeaddons -f -
> apiVersion: constraints.gatekeeper.sh/v1beta1
> kind: K8sPSPHostFilesystem
> metadata:
>   name: psp-host-filesystem
> spec:
>   match:
>     kinds:
>       - apiGroups: [""]
>         kinds: ["Pod"]
>   parameters:
>     allowedHostPaths:
>     - readOnly: true
>       pathPrefix: "/foo"
> EOF
k8spsphostfilesystem.constraints.gatekeeper.sh/psp-host-filesystem created
```
3. Check if the Constraint is enforced as expected by creating a Pod which mounts on a host path which is not allowed
```
$ cat <<EOF | kubectl apply -n kubeaddons -f -
> apiVersion: v1
> kind: Pod
> metadata:
>   name: nginx-host-filesystem
>   labels:
>     app: nginx-host-filesystem
> spec:
>   containers:
>   - name: nginx
>     image: nginx
>     volumeMounts:
>     - mountPath: /cache
>       name: cache-volume
>       readOnly: true
>   volumes:
>   - name: cache-volume
>     hostPath:
>       path: /tmp # directory location on host
> EOF
Error from server ([denied by psp-host-filesystem] HostPath volume {"name": "cache-volume", "hostPath": {"path": "/tmp", "type": ""}} is not allowed, pod: nginx-host-filesystem. Allowed path: [{"pathPrefix": "/foo", "readOnly": true}]): error when creating "STDIN": admission webhook "validation.gatekeeper.sh" denied the request: [denied by psp-host-filesystem] HostPath volume {"name": "cache-volume", "hostPath": {"path": "/tmp", "type": ""}} is not allowed, pod: nginx-host-filesystem. Allowed path: [{"pathPrefix": "/foo", "readOnly": true}]
```

Received an error message from server. So, policy is enforced as expected.