### PR TITLE
prometheus: Set externalLabels cluster label to kube-system ns uid

### DIFF
--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -56,8 +56,8 @@ spec:
           - kibana-prometheus-exporter,6.7.0,https://github.com/pjhampton/kibana-prometheus-exporter/releases/download/6.7.0/kibana-prometheus-exporter-6.7.0.zip
       extraContainers: |
         - name: initialize-kibana-index
-          image: mesosphere/kubeaddons-addon-initializer:v0.0.4
-          command: ["/bin/bash", "-c", "addon-initializer kibana && while true; do sleep 86400; done"]
+          image: mesosphere/kubeaddons-addon-initializer:v0.0.13
+          command: ["/bin/bash", "-c", "addon-initializer kibana && sleep infinity"]
           env:
           - name: "KIBANA_NAMESPACE"
             value: "kubeaddons"

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -106,8 +106,8 @@ spec:
             # note: in order to run this container, mesosphereResources.enableAdditionalPrometheusRBACRules
             # needs to be set to true
             - name: get-cluster-id
-              image: mesosphere/kubeaddons-addon-initializer:v0.0.12
-              command: ["/bin/bash", "-c", "addon-initializer prometheus && while true; do sleep 86400; done"]
+              image: mesosphere/kubeaddons-addon-initializer:v0.0.13
+              command: ["/bin/bash", "-c", "addon-initializer prometheus && sleep infinity"]
               env:
               - name: "PROMETHEUS_NAMESPACE"
                 value: "kubeaddons"

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -19,7 +19,7 @@ metadata:
     docs.kubeaddons.mesosphere.io/prometheus: "https://prometheus.io/docs/introduction/overview/"
     docs.kubeaddons.mesosphere.io/grafana: "https://grafana.com/docs/"
     docs.kubeaddons.mesosphere.io/alertmanager: "https://prometheus.io/docs/alerting/alertmanager/"
-    values.chart.helm.kubeaddons.mesosphere.io/prometheus: "https://raw.githubusercontent.com/mesosphere/charts/6e22a56951dbe295c64f83b06f7c059fe4d612ce/staging/prometheus-operator/values.yaml"
+    values.chart.helm.kubeaddons.mesosphere.io/prometheus: "https://raw.githubusercontent.com/mesosphere/charts/3bc311e3fae9d608c528433963bf67ca6827513c/staging/prometheus-operator/values.yaml"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
@@ -33,7 +33,7 @@ spec:
   chartReference:
     chart: prometheus-operator
     repo: https://mesosphere.github.io/charts/staging
-    version: 5.19.1
+    version: 5.19.2
     values: |
       ---
       defaultRules:
@@ -46,6 +46,10 @@ spec:
           # addon alert rules are defaulted to false to prevent potential misfires if addons
           # are disabled.
           velero: false
+        # This option grants the Prometheus pod the necessary permissions that the
+        # "get-cluster-id" container defined in prometheus.prometheusSpec.containers requires.
+        # see: https://github.com/mesosphere/kubeaddons-extrasteps/tree/master/pkg/prometheus/prometheus.go
+        enableAdditionalPrometheusRBACRules: true
       prometheus:
         service:
           additionalPorts:
@@ -96,6 +100,25 @@ spec:
           thanos:
             baseImage: thanosio/thanos
             version: v0.4.0
+          externalLabels:
+            cluster: $(CLUSTER_ID)
+          containers:
+            # note: in order to run this container, mesosphereResources.enableAdditionalPrometheusRBACRules
+            # needs to be set to true
+            - name: get-cluster-id
+              image: mesosphere/kubeaddons-addon-initializer:v0.0.12
+              command: ["/bin/bash", "-c", "addon-initializer prometheus && while true; do sleep 86400; done"]
+              env:
+              - name: "PROMETHEUS_NAMESPACE"
+                value: "kubeaddons"
+              - name: "CLUSTER_ID_CONFIGMAP_NAME"
+                value: "cluster-info-configmap"
+              - name: "KUBESYSTEM_NAMESPACE"
+                value: "kube-system"
+            - name: prometheus-config-reloader
+              envFrom:
+              - configMapRef:
+                  name: cluster-info-configmap
           additionalScrapeConfigs:
             - job_name: 'kubernetes-nodes-containerd'
               metrics_path: /v1/metrics

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -113,8 +113,6 @@ spec:
                 value: "kubeaddons"
               - name: "CLUSTER_ID_CONFIGMAP_NAME"
                 value: "cluster-info-configmap"
-              - name: "KUBESYSTEM_NAMESPACE"
-                value: "kube-system"
             - name: prometheus-config-reloader
               envFrom:
               - configMapRef:


### PR DESCRIPTION
Please see https://github.com/mesosphere/kubeaddons-extrasteps/pull/22 for a full description of this work. The extrasteps functionality is pulled into a prometheus container - ideally this would be an initContainer, but that feature was introduced in a later version of prometheus-operator ([0.32.0](https://github.com/coreos/prometheus-operator/releases/tag/v0.32.0), or helm chart versions >=6.8.0; we are on 5.19). When we eventually upgrade to a high enough version, we should move this into an initContainer. Until it is moved to an initContainer, there will be some errors (pasted below) in the reload and thanos sidecar containers until the configmap is written out and the env variable is defined, but it's pretty quick.

![image](https://user-images.githubusercontent.com/5897740/66578971-0bd31180-eb4a-11e9-8fb3-cff28ff5bcc2.png)
![image](https://user-images.githubusercontent.com/5897740/66579106-48067200-eb4a-11e9-8b55-06d200b27826.png)
![image](https://user-images.githubusercontent.com/5897740/66579225-7b490100-eb4a-11e9-8ba7-9784df2fa701.png)


When the corresponding extrasteps and chart PRs are merged in, I'll update this to point to the correct chart/image.