### PR TITLE
Use Prometheus v2.9.2

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -9,10 +9,10 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.29.0"
-    appversion.kubeaddons.mesosphere.io/prometheus: "2.9.1"
-    appversion.kubeaddons.mesosphere.io/alertmanager: "0.16.2"
-    appversion.kubeaddons.mesosphere.io/grafana: "6.1.6"
+    appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.31.1"
+    appversion.kubeaddons.mesosphere.io/prometheus: "2.9.2"
+    appversion.kubeaddons.mesosphere.io/alertmanager: "0.17.0"
+    appversion.kubeaddons.mesosphere.io/grafana: "6.2.5"
     endpoint.kubeaddons.mesosphere.io/prometheus: "/ops/portal/prometheus"
     endpoint.kubeaddons.mesosphere.io/alertmanager: "/ops/portal/alertmanager"
     endpoint.kubeaddons.mesosphere.io/grafana: "/ops/portal/grafana"
@@ -85,6 +85,8 @@ spec:
                 targetPort: 5601
                 interval: 30s
         prometheusSpec:
+          image:
+            tag: v2.9.2
           thanos:
             baseImage: thanosio/thanos
             version: v0.4.0


### PR DESCRIPTION
The new Prometheus Alerts UI design isn't ideal:

![image](https://user-images.githubusercontent.com/5897740/66619753-132b0700-ebac-11e9-9361-48c96c0263b1.png)

The UI enhancement was released in Prometheus v2.10.0 -- let's use Prometheus v2.9.2 instead (it is defaulted to v2.10.0 in the helm chart), and upgrade once that design is improved (there is a [PR open](https://github.com/prometheus/prometheus/issues/5655) that looks like it'll improve the UI). I've also updated the labels to correctly reflect the versions of each component in prometheus-operator.

UI using v2.9.2:
![image](https://user-images.githubusercontent.com/5897740/66619862-6ef59000-ebac-11e9-9530-d0d6d9e6af52.png)
