### PR TITLE
default storage class addon and requirements

### DIFF
--- a/templates/awsebscsiprovisioner.yaml
+++ b/templates/awsebscsiprovisioner.yaml
@@ -11,6 +11,9 @@ metadata:
     appversion.kubeaddons.mesosphere.io/awsebscsiprovisioner: "0.4.0"
     values.chart.helm.kubeaddons.mesosphere.io/awsebscsiprovisioner: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/awsebscsiprovisioner/values.yaml"
 spec:
+  requires:
+    matchLabels:
+      kubeaddons.mesosphere.io/name: defaultstorageclass
   kubernetes:
     minSupportedVersion: v1.15.0
   namespace: kube-system

--- a/templates/awsebscsiprovisioner.yaml
+++ b/templates/awsebscsiprovisioner.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   requires:
     matchLabels:
-      kubeaddons.mesosphere.io/name: defaultstorageclass
+      kubeaddons.mesosphere.io/name: defaultstorageclass-protection
   kubernetes:
     minSupportedVersion: v1.15.0
   namespace: kube-system

--- a/templates/awsebsprovisioner.yaml
+++ b/templates/awsebsprovisioner.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   requires:
     matchLabels:
-      kubeaddons.mesosphere.io/name: defaultstorageclass
+      kubeaddons.mesosphere.io/name: defaultstorageclass-protection
   kubernetes:
     minSupportedVersion: v1.15.0
   cloudProvider:

--- a/templates/awsebsprovisioner.yaml
+++ b/templates/awsebsprovisioner.yaml
@@ -11,6 +11,9 @@ metadata:
     appversion.kubeaddons.mesosphere.io/awsebsprovisioner: "1.0"
     values.chart.helm.kubeaddons.mesosphere.io/awsebsprovisioner: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/awsebsprovisioner/values.yaml"
 spec:
+  requires:
+    matchLabels:
+      kubeaddons.mesosphere.io/name: defaultstorageclass
   kubernetes:
     minSupportedVersion: v1.15.0
   cloudProvider:

--- a/templates/defaultstorageclass.yaml
+++ b/templates/defaultstorageclass.yaml
@@ -1,12 +1,12 @@
 apiVersion: kubeaddons.mesosphere.io/v1alpha1
 kind: Addon
 metadata:
-  name: defaultstorageclass
+  name: defaultstorageclass-protection
   namespace: kubeaddons
   labels:
-    kubeaddons.mesosphere.io/name: defaultstorageclass
+    kubeaddons.mesosphere.io/name: defaultstorageclass-protection
   annotations:
-    appversion.kubeaddons.mesosphere.io/defaultstorageclass: "0.0.1"
+    appversion.kubeaddons.mesosphere.io/defaultstorageclass-protection: "0.0.1"
 spec:
   requires:
     matchLabels:

--- a/templates/defaultstorageclass.yaml
+++ b/templates/defaultstorageclass.yaml
@@ -1,0 +1,30 @@
+apiVersion: kubeaddons.mesosphere.io/v1alpha1
+kind: Addon
+metadata:
+  name: defaultstorageclass
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: defaultstorageclass
+  annotations:
+    appversion.kubeaddons.mesosphere.io/defaultstorageclass: "0.0.1"
+spec:
+  requires:
+    matchLabels:
+      kubeaddons.mesosphere.io/name: cert-manager
+  kubernetes:
+    minSupportedVersion: v1.15.0
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
+  chartReference:
+    chart: defaultstorageclass
+    repo: https://mesosphere.github.io/charts/stable
+    version: 0.0.1
+    values: |
+      ---
+      issuer:
+        name: kubernetes-ca

--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -11,6 +11,9 @@ metadata:
     appversion.kubeaddons.mesosphere.io/localvolumeprovisioner: "1.0"
     values.chart.helm.kubeaddons.mesosphere.io/localvolumeprovisioner: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/localvolumeprovisioner/values.yaml"
 spec:
+  requires:
+    matchLabels:
+      kubeaddons.mesosphere.io/name: defaultstorageclass
   kubernetes:
     minSupportedVersion: v1.15.0
   namespace: kube-system 

--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   requires:
     matchLabels:
-      kubeaddons.mesosphere.io/name: defaultstorageclass
+      kubeaddons.mesosphere.io/name: defaultstorageclass-protection
   kubernetes:
     minSupportedVersion: v1.15.0
   namespace: kube-system 


### PR DESCRIPTION
there has been a discussion about how to handle cases where there are 2 default storage classes, as that can create errors for other addons down the road.

part of this solution is having a validating webhook that checks for whether 2 default storage classes installed, see kep: https://github.com/mesosphere/kubeaddons/blob/master/keps/20190903-defaultstorageclass-validating-webhook.md

this is implemented in: https://github.com/mesosphere/charts/pull/124

to protect users from having multiple default storageclasses, all storageclass addons now have this addon as a requirement. as written in the PR.