### PR TITLE
dex: bump to use dex-controller v0.2.0

### DIFF
--- a/templates/dex.yaml
+++ b/templates/dex.yaml
@@ -24,7 +24,7 @@ spec:
   chartReference:
     chart: dex
     repo: https://mesosphere.github.io/charts/stable
-    version: 1.6.5
+    version: 1.6.6
     values: |
       ---
       # Temporarily we're going to use our custom built container. Documentation


### PR DESCRIPTION
Bump to use dex-controller v0.2.0 that supports static clients.