### PR TITLE
Add service port for Thanos gRPC

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -47,6 +47,12 @@ spec:
           # are disabled.
           velero: false
       prometheus:
+        service:
+          additionalPorts:
+            # Service port for Thanos gRPC.
+            - name: grpc
+              port: 10901
+              targetPort: grpc
         additionalServiceMonitors:
           - name: kubeaddons-service-monitor-metrics
             selector:


### PR DESCRIPTION
This adds a port to the Prometheus service that exposes the Thanos sidecar's gRPC. I tested this by deploying Konvoy with this config and observing that `kubectl -n kubeaddons describe service prometheus-kubeaddons-prom-prometheus` shows the added gRPC port.

This gRPC service will be used by Thanos Querier, running as part of Kommander. Querier will be added in a separate PR.

https://jira.mesosphere.com/browse/DCOS-59074