### PR TITLE
kube-oidc-proxy: add groupsPrefix

### DIFF
--- a/templates/kube-oidc-proxy.yaml
+++ b/templates/kube-oidc-proxy.yaml
@@ -51,6 +51,7 @@ spec:
         # updated by initcontainer when working with a remote dex
         issuerUrl: https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex
         usernameClaim: email
+        groupsPrefix: "oidc:"
         # placeholder : updated by initcontainer
         caPEM: "placeholder"
       initContainers:


### PR DESCRIPTION
This PR adds `goupsPrefix` parameter. This is a fix for regression when we've switched from configuring `kube-apiserver` with `kube-oidc-proxy`.

Successful docker build:

https://github.com/mesosphere/konvoy/pull/908
https://teamcity.mesosphere.io/viewLog.html?buildId=2361673&buildTypeId=ClosedSource_Konvoy_KonvoyE2eDocker