### PR TITLE
dashboard/prometheus: use gcr.io/google_containers instead of k8s.gcr.io

### DIFF
--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -32,3 +32,8 @@ spec:
         requests:
           cpu: 500m
           memory: 300Mi
+      image:
+        # override the default k8s.gcr.io/kubernetes-dashboard-amd64 repositry
+        # containerd mirror functionality does not support pulling these images
+        # TODO remove once https://github.com/containerd/containerd/issues/3756 is resolved
+        repository: gcr.io/google_containers/kubernetes-dashboard-amd64

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -246,3 +246,9 @@ spec:
           caFile: "/etc/prometheus/secrets/etcd-certs/ca.crt"
           certFile: "/etc/prometheus/secrets/etcd-certs/server.crt"
           keyFile: "/etc/prometheus/secrets/etcd-certs/server.key"
+      kube-state-metrics:
+        image:
+          # override the default k8s.gcr.io/kube-state-metrics repositry
+          # containerd mirror functionality does not support pulling these images
+          # TODO remove once https://github.com/containerd/containerd/issues/3756 is resolved
+          repository: gcr.io/google_containers/kube-state-metrics


### PR DESCRIPTION
The `k8s.gcr.io` is just an alias to `gcr.io/google_containerrs`, overriding the repository for the images that need it.

After this change and using a private registry with modified `/etc/hosts` file to block access to the upstream registries.

The list of all the pods that were released.
```
➜  dkkonvoyimages k get pods --all-namespaces -o wide
NAMESPACE               NAME                                                                READY   STATUS      RESTARTS   AGE     IP                NODE                                         NOMINATED NODE   READINESS GATES
cert-manager            cert-manager-kubeaddons-58fdfcdc64-m287c                            1/1     Running     0          4m18s   192.168.219.132   ip-10-0-129-94.us-west-2.compute.internal    <none>           <none>
cert-manager            cert-manager-kubeaddons-cainjector-5874d7756-lm8pf                  1/1     Running     0          4m18s   192.168.102.68    ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
cert-manager            cert-manager-kubeaddons-webhook-767fbcbc78-pscdq                    1/1     Running     1          4m18s   192.168.196.134   ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kommander               kcl-cm-bc79bdd49-vbvpq                                              2/2     Running     0          2m18s   192.168.196.142   ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kommander               kcl-tfcb-6b98cd5997-f8vmb                                           1/1     Running     0          2m18s   192.168.201.207   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kommander               kcl-webhook-6fd7b9bbf8-nvxqw                                        1/1     Running     0          2m18s   192.168.201.208   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kommander               kommander-kubeaddons-c78bc947c-rwlw7                                1/1     Running     0          2m18s   192.168.196.141   ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kommander               kubefed-admission-webhook-7fdcc5b56f-zct7t                          1/1     Running     0          2m18s   192.168.201.205   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kommander               kubefed-controller-manager-75bdd8c787-9ckb4                         1/1     Running     0          2m18s   192.168.196.140   ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kommander               kubefed-controller-manager-75bdd8c787-mb6x4                         1/1     Running     0          2m18s   192.168.201.206   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kube-system             calico-kube-controllers-66d6bf49f6-fv4hl                            1/1     Running     0          5m17s   192.168.196.129   ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kube-system             calico-node-5ll2f                                                   2/2     Running     0          5m17s   10.0.129.94       ip-10-0-129-94.us-west-2.compute.internal    <none>           <none>
kube-system             calico-node-7pcs9                                                   2/2     Running     0          5m17s   10.0.128.120      ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kube-system             calico-node-fzzzg                                                   2/2     Running     0          5m17s   10.0.131.212      ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
kube-system             calico-node-gt29f                                                   2/2     Running     0          5m17s   10.0.128.176      ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kube-system             calico-node-xdgkz                                                   2/2     Running     0          5m17s   10.0.193.71       ip-10-0-193-71.us-west-2.compute.internal    <none>           <none>
kube-system             coredns-58bb7877fc-hz5nb                                            1/1     Running     0          5m52s   192.168.219.129   ip-10-0-129-94.us-west-2.compute.internal    <none>           <none>
kube-system             coredns-58bb7877fc-kfmtb                                            1/1     Running     0          5m52s   192.168.102.65    ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
kube-system             ebs-csi-controller-0                                                5/5     Running     0          4m34s   192.168.219.131   ip-10-0-129-94.us-west-2.compute.internal    <none>           <none>
kube-system             ebs-csi-node-44vh2                                                  3/3     Running     0          4m34s   10.0.193.71       ip-10-0-193-71.us-west-2.compute.internal    <none>           <none>
kube-system             ebs-csi-node-bwr6p                                                  3/3     Running     0          4m34s   10.0.131.212      ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
kube-system             ebs-csi-node-f5nw8                                                  3/3     Running     0          4m34s   10.0.129.94       ip-10-0-129-94.us-west-2.compute.internal    <none>           <none>
kube-system             ebs-csi-node-mb2j2                                                  3/3     Running     0          4m34s   10.0.128.120      ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kube-system             ebs-csi-node-wplrn                                                  3/3     Running     0          4m34s   10.0.128.176      ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kube-system             etcd-ip-10-0-193-71.us-west-2.compute.internal                      1/1     Running     0          4m53s   10.0.193.71       ip-10-0-193-71.us-west-2.compute.internal    <none>           <none>
kube-system             kube-apiserver-ip-10-0-193-71.us-west-2.compute.internal            1/1     Running     0          5m11s   10.0.193.71       ip-10-0-193-71.us-west-2.compute.internal    <none>           <none>
kube-system             kube-controller-manager-ip-10-0-193-71.us-west-2.compute.internal   1/1     Running     0          4m56s   10.0.193.71       ip-10-0-193-71.us-west-2.compute.internal    <none>           <none>
kube-system             kube-proxy-5lz74                                                    1/1     Running     0          5m51s   10.0.193.71       ip-10-0-193-71.us-west-2.compute.internal    <none>           <none>
kube-system             kube-proxy-bsvgn                                                    1/1     Running     0          5m25s   10.0.131.212      ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
kube-system             kube-proxy-fhr8p                                                    1/1     Running     0          5m25s   10.0.128.120      ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kube-system             kube-proxy-gtmfs                                                    1/1     Running     0          5m25s   10.0.129.94       ip-10-0-129-94.us-west-2.compute.internal    <none>           <none>
kube-system             kube-proxy-gz4xk                                                    1/1     Running     0          5m24s   10.0.128.176      ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kube-system             kube-scheduler-ip-10-0-193-71.us-west-2.compute.internal            1/1     Running     0          5m8s    10.0.193.71       ip-10-0-193-71.us-west-2.compute.internal    <none>           <none>
kube-system             kubernetes-dashboard-5ccc7dfc6c-25fqw                               1/1     Running     0          4m34s   192.168.102.67    ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
kube-system             tiller-deploy-8557598fbc-lb8hr                                      1/1     Running     0          4m51s   192.168.201.194   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kubeaddons              alertmanager-prometheus-kubeaddons-prom-alertmanager-0              2/2     Running     0          3m58s   192.168.201.201   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kubeaddons              bearerproxy-7bcfc4cdbd-c7mb6                                        1/1     Running     0          4m8s    192.168.201.199   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kubeaddons              dex-k8s-authenticator-kubeaddons-847c9b6ddf-52x7q                   1/1     Running     2          77s     192.168.219.139   ip-10-0-129-94.us-west-2.compute.internal    <none>           <none>
kubeaddons              dex-kubeaddons-6d946c5674-zdhz4                                     1/1     Running     1          103s    192.168.102.79    ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
kubeaddons              dex-kubeaddons-dex-controller-5b8cfff789-928vv                      2/2     Running     0          114s    192.168.102.78    ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
kubeaddons              elasticsearch-kubeaddons-client-5d7f8594f9-bdxrh                    1/1     Running     0          4m25s   192.168.201.196   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kubeaddons              elasticsearch-kubeaddons-client-5d7f8594f9-sv8gg                    1/1     Running     0          4m25s   192.168.196.133   ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kubeaddons              elasticsearch-kubeaddons-data-0                                     1/1     Running     0          4m25s   192.168.196.136   ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kubeaddons              elasticsearch-kubeaddons-data-1                                     1/1     Running     0          2m56s   192.168.201.204   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kubeaddons              elasticsearch-kubeaddons-master-0                                   1/1     Running     0          4m25s   192.168.201.200   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kubeaddons              elasticsearch-kubeaddons-master-1                                   1/1     Running     0          3m2s    192.168.102.75    ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
kubeaddons              elasticsearch-kubeaddons-master-2                                   1/1     Running     0          2m15s   192.168.219.137   ip-10-0-129-94.us-west-2.compute.internal    <none>           <none>
kubeaddons              elasticsearchexporter-kubeaddons-elasticsearch-exporter-565549s     1/1     Running     0          75s     192.168.102.80    ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
kubeaddons              fluentbit-kubeaddons-fluent-bit-5mrgl                               1/1     Running     0          4m34s   192.168.188.65    ip-10-0-193-71.us-west-2.compute.internal    <none>           <none>
kubeaddons              fluentbit-kubeaddons-fluent-bit-btfvf                               1/1     Running     0          4m34s   192.168.219.130   ip-10-0-129-94.us-west-2.compute.internal    <none>           <none>
kubeaddons              fluentbit-kubeaddons-fluent-bit-hdz4b                               1/1     Running     0          4m34s   192.168.196.131   ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kubeaddons              fluentbit-kubeaddons-fluent-bit-qrpfn                               1/1     Running     0          4m34s   192.168.201.195   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kubeaddons              fluentbit-kubeaddons-fluent-bit-qv2hz                               1/1     Running     0          4m34s   192.168.102.66    ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
kubeaddons              kibana-kubeaddons-76c6bdcdd4-bb4rw                                  2/2     Running     0          74s     192.168.102.81    ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
kubeaddons              kube-oidc-proxy-kubeaddons-79d6bf65d9-4rq9j                         1/1     Running     0          116s    192.168.102.77    ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
kubeaddons              kubeaddons-catalog-5cbb7ccd47-92q2t                                 1/1     Running     0          5m12s   192.168.201.193   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kubeaddons              kubeaddons-controller-manager-5748cbfb7d-k9qh5                      1/1     Running     0          5m13s   192.168.196.130   ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kubeaddons              opsportal-kubeaddons-kommander-7cd9fb8fb7-n4pkk                     1/1     Running     0          4m8s    192.168.201.198   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kubeaddons              opsportal-landing-6c5b7f789d-rrlv4                                  1/1     Running     0          4m8s    192.168.102.69    ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
kubeaddons              prometheus-kubeaddons-grafana-6fb5dfb868-xgfnd                      2/2     Running     0          4m10s   192.168.219.133   ip-10-0-129-94.us-west-2.compute.internal    <none>           <none>
kubeaddons              prometheus-kubeaddons-kube-state-metrics-84dcbd849-lmrnb            1/1     Running     0          4m10s   192.168.196.135   ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kubeaddons              prometheus-kubeaddons-prom-operator-5c7fb5d5f7-rwxv9                1/1     Running     0          4m10s   192.168.201.197   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kubeaddons              prometheus-kubeaddons-prometheus-node-exporter-88zns                1/1     Running     0          4m10s   10.0.128.120      ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
kubeaddons              prometheus-kubeaddons-prometheus-node-exporter-bpcb4                1/1     Running     0          4m10s   10.0.193.71       ip-10-0-193-71.us-west-2.compute.internal    <none>           <none>
kubeaddons              prometheus-kubeaddons-prometheus-node-exporter-fgn2w                1/1     Running     0          4m10s   10.0.129.94       ip-10-0-129-94.us-west-2.compute.internal    <none>           <none>
kubeaddons              prometheus-kubeaddons-prometheus-node-exporter-pcj96                1/1     Running     0          4m10s   10.0.128.176      ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kubeaddons              prometheus-kubeaddons-prometheus-node-exporter-zdj25                1/1     Running     0          4m10s   10.0.131.212      ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
kubeaddons              prometheus-prometheus-kubeaddons-prom-prometheus-0                  4/4     Running     1          3m48s   192.168.196.137   ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kubeaddons              prometheusadapter-kubeaddons-prometheus-adapter-98776b569-m2qf7     1/1     Running     0          3m26s   192.168.219.135   ip-10-0-129-94.us-west-2.compute.internal    <none>           <none>
kubeaddons              traefik-forward-auth-kubeaddons-b9d75cb98-b84pj                     1/1     Running     0          47s     192.168.102.83    ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
kubeaddons              traefik-kubeaddons-1.72.4-7rjwv                                     0/1     Completed   0          2m41s   192.168.196.139   ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
kubeaddons              traefik-kubeaddons-f77ccbdd5-h4k5s                                  1/1     Running     0          2m41s   192.168.219.136   ip-10-0-129-94.us-west-2.compute.internal    <none>           <none>
kubeaddons              traefik-kubeaddons-f77ccbdd5-mx9t2                                  1/1     Running     0          2m41s   192.168.102.76    ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
velero-minio-operator   minio-operator-644cf58c6b-2pmfj                                     1/1     Running     0          3m47s   192.168.102.70    ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
velero                  minio-0                                                             1/1     Running     0          3m43s   192.168.102.74    ip-10-0-131-212.us-west-2.compute.internal   <none>           <none>
velero                  minio-1                                                             1/1     Running     0          3m43s   192.168.219.134   ip-10-0-129-94.us-west-2.compute.internal    <none>           <none>
velero                  minio-2                                                             1/1     Running     0          3m43s   192.168.201.203   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
velero                  minio-3                                                             1/1     Running     0          3m43s   192.168.196.138   ip-10-0-128-176.us-west-2.compute.internal   <none>           <none>
velero                  velero-kubeaddons-fb5868878-dhwpx                                   1/1     Running     0          3m47s   192.168.201.202   ip-10-0-128-120.us-west-2.compute.internal   <none>           <none>
```

Containerd mirror feature can not pull k8s.gcr.io images https://github.com/containerd/containerd/issues/3756