### PR TITLE
Add Catalog annotations to addons

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,8 @@ The overall workflow for contributing a new Addon is:
 5. test the addon functionality as appropriate for its type
 
 1. Manual testing of the Addon has succeeded against the most recent release of the `kubeaddons` controller
-2. CI must pass
+2. Manual testing of the Addon has succeeded against the most recent release of the `kubeaddons catalog`
+3. CI must pass
 
 ## Customizing Existing Addons
 

--- a/templates/awsebscsiprovisioner.yaml
+++ b/templates/awsebscsiprovisioner.yaml
@@ -8,6 +8,7 @@ metadata:
     kubeaddons.mesosphere.io/name: awsebscsiprovisioner
     kubeaddons.mesosphere.io/provides: storageclass
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.4.0-1"
     appversion.kubeaddons.mesosphere.io/awsebscsiprovisioner: "0.4.0"
     values.chart.helm.kubeaddons.mesosphere.io/awsebscsiprovisioner: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/awsebscsiprovisioner/values.yaml"
 spec:

--- a/templates/awsebsprovisioner.yaml
+++ b/templates/awsebsprovisioner.yaml
@@ -8,6 +8,7 @@ metadata:
     kubeaddons.mesosphere.io/name: awsebsprovisioner
     kubeaddons.mesosphere.io/provides: storageclass
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-1"
     appversion.kubeaddons.mesosphere.io/awsebsprovisioner: "1.0"
     values.chart.helm.kubeaddons.mesosphere.io/awsebsprovisioner: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/awsebsprovisioner/values.yaml"
 spec:

--- a/templates/cert-manager.yaml
+++ b/templates/cert-manager.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: cert-manager
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.10.1-1"
     appversion.kubeaddons.mesosphere.io/cert-manager: "0.10.1"
     docs.kubeaddons.mesosphere.io/cert-manager: "https://docs.cert-manager.io/en/release-0.10/"
     values.chart.helm.kubeaddons.mesosphere.io/cert-manager: "https://raw.githubusercontent.com/mesosphere/charts/1b68b80a4384946575952fe095ce46510e5badad/staging/cert-manager-setup/values.yaml"

--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dashboard
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.10.1-1"
     appversion.kubeaddons.mesosphere.io/dashboard: "1.10.1"
     endpoint.kubeaddons.mesosphere.io/dashboard: "/ops/portal/kubernetes/"
     docs.kubeaddons.mesosphere.io/dashboard: "https://github.com/kubernetes/dashboard/blob/master/README.md"

--- a/templates/defaultstorageclass.yaml
+++ b/templates/defaultstorageclass.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: defaultstorageclass-protection
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.0.1-1"
     appversion.kubeaddons.mesosphere.io/defaultstorageclass-protection: "0.0.1"
 spec:
   requires:

--- a/templates/dex-k8s-authenticator.yaml
+++ b/templates/dex-k8s-authenticator.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dex-k8s-authenticator
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-1"
     appversion.kubeaddons.mesosphere.io/dex-k8s-authenticator: "v1.1.0"
     values.chart.helm.kubeaddons.mesosphere.io/dex-k8s-authenticator: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/staging/dex-k8s-authenticator/values.yaml"
 spec:

--- a/templates/dex.yaml
+++ b/templates/dex.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dex
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "2.16.0-1"
     appversion.kubeaddons.mesosphere.io/dex: "2.16.0"
     values.chart.helm.kubeaddons.mesosphere.io/dex: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/dex/values.yaml"
 spec:

--- a/templates/elasticsearch.yaml
+++ b/templates/elasticsearch.yaml
@@ -10,6 +10,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "6.7.0-1"
     appversion.kubeaddons.mesosphere.io/elasticsearch: "6.7.0"
     values.chart.helm.kubeaddons.mesosphere.io/elasticsearch: "https://raw.githubusercontent.com/helm/charts/6bfbc8018cd4440637b07c7559d5812e4d9db34d/stable/elasticsearch/values.yaml"
 spec:

--- a/templates/elasticsearchexporter.yaml
+++ b/templates/elasticsearchexporter.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: elasticsearchexporter
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.2-1"
     appversion.kubeaddons.mesosphere.io/elasticsearchexporter: "1.0.2"
     values.chart.helm.kubeaddons.mesosphere.io/elasticsearchexporter: "https://raw.githubusercontent.com/helm/charts/08fc376647d43169743dcf04f1e88a2aec9e5f3d/stable/elasticsearch-exporter/values.yaml"
 spec:

--- a/templates/fluentbit.yaml
+++ b/templates/fluentbit.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: fluentbit
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.1-1"
     appversion.kubeaddons.mesosphere.io/fluentbit: "1.2.1"
     values.chart.helm.kubeaddons.mesosphere.io/fluentbit: "https://raw.githubusercontent.com/helm/charts/f9efc8de7dcd6f93ebacc4b321d01a5aa819cdaa/stable/fluent-bit/values.yaml"
 spec:

--- a/templates/gatekeeper.yaml
+++ b/templates/gatekeeper.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: gatekeeper
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "3.0.4-1"
     appversion.kubeaddons.mesosphere.io/gatekeeper: "3.0.4-beta.1"
     docs.kubeaddons.mesosphere.io/gatekeeper: "https://github.com/open-policy-agent/gatekeeper/blob/master/README.md"
     values.chart.helm.kubeaddons.mesosphere.io/gatekeeper: "https://raw.githubusercontent.com/mesosphere/charts/f52ab9415b53aee946ff8e55a60b50be193b7ea7/staging/gatekeeper/values.yaml"

--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kibana
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "6.7.0-1"
     appversion.kubeaddons.mesosphere.io/kibana: "6.7.0"
     endpoint.kubeaddons.mesosphere.io/kibana: "/ops/portal/kibana"
     docs.kubeaddons.mesosphere.io/kibana: "https://www.elastic.co/guide/en/kibana/6.7/index.html"

--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.116.17-1"
     appversion.kubeaddons.mesosphere.io/kommander: "1.116.17"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander
     values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/master/stable/kommander/values.yaml"

--- a/templates/konvoyconfig.yaml
+++ b/templates/konvoyconfig.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     kubaddons.mesosphere.io/name: konvoyconfig
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.0.1-1"
     appversion.kubeaddons.mesosphere.io/konvoyconfig: "0.0.1"
     values.chart.helm.kubeaddons.mesosphere.io/konvoyconfig: "https://raw.githubusercontent.com/mesosphere/charts/173f2200647defaf67e96b32cfdbb5b6932f1fa5/staging/konvoyconfig/values.yaml"
 spec:

--- a/templates/kube-oidc-proxy.yaml
+++ b/templates/kube-oidc-proxy.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kube-oidc-proxy
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.1.1-1"
     appversion.kubeaddons.mesosphere.io/kube-oidc-proxy: "v0.1.1"
     values.chart.helm.kubeaddons.mesosphere.io/kube-oidc-proxy: "https://raw.githubusercontent.com/mesosphere/charts/fb01c5b81bb77e78d3a9ff5f5d8ec4b2703c5fb4/staging/kube-oidc-proxy/values.yaml"
 spec:

--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -8,6 +8,7 @@ metadata:
     kubeaddons.mesosphere.io/name: localvolumeprovisioner
     kubeaddons.mesosphere.io/provides: storageclass
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-1"
     appversion.kubeaddons.mesosphere.io/localvolumeprovisioner: "1.0"
     values.chart.helm.kubeaddons.mesosphere.io/localvolumeprovisioner: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/localvolumeprovisioner/values.yaml"
 spec:

--- a/templates/metallb.yaml
+++ b/templates/metallb.yaml
@@ -7,6 +7,7 @@ metadata:
     kubeaddons.mesosphere.io/name: metallb
     kubeaddons.mesosphere.io/provides: loadbalancer
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.7.3-1"
     appversion.kubeaddons.mesosphere.io/metallb: "0.7.3"
     values.chart.helm.kubeaddons.mesosphere.io/metallb: "https://raw.githubusercontent.com/helm/charts/b0f9cb2d7af822e0031f632f2faa0cbb53167770/stable/metallb/values.yaml"
 spec:

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -8,6 +8,7 @@ metadata:
     kubeaddons.mesosphere.io/name: nvidia
     kubeaddons.mesosphere.io/provides: nvidia
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.1.0-1"
     appversion.kubeaddons.mesosphere.io/nvidia: "0.1"
     values.chart.helm.kubeaddons.mesosphere.io/nvidia: "https://raw.githubusercontent.com/mesosphere/charts/869a26a8d4061d5b407cd260eac2eee9149f2823/staging/nvidia/values.yaml"
 spec:

--- a/templates/opsportal.yaml
+++ b/templates/opsportal.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: opsportal
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-1"
     appversion.kubeaddons.mesosphere.io/opsportal: "1.0.0"
     endpoint.kubeaddons.mesosphere.io/opsportal: /ops/portal/
     values.chart.helm.kubeaddons.mesosphere.io/opsportal: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/stable/opsportal/values.yaml"

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -9,6 +9,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.31.1-1"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.31.1"
     appversion.kubeaddons.mesosphere.io/prometheus: "2.9.2"
     appversion.kubeaddons.mesosphere.io/alertmanager: "0.17.0"

--- a/templates/prometheusadapter.yaml
+++ b/templates/prometheusadapter.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: prometheusadapter
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.5.0-1"
     appversion.kubeaddons.mesosphere.io/prometheusadapter: "0.5.0"
     values.chart.helm.kubeaddons.mesosphere.io/prometheusadapter: "https://raw.githubusercontent.com/helm/charts/db62a6c595bbd9904014083edd0faa14de4096b2/stable/prometheus-adapter/values.yaml"
 spec:

--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -3,6 +3,8 @@ kind: Addon
 metadata:
   name: traefik-forward-auth
   namespace: kubeaddons
+  annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.4-1"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -10,6 +10,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.68.4-1"
     appversion.kubeaddons.mesosphere.io/traefik: "1.68.4"
     endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
     docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/v1.7"

--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -31,6 +31,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.1-1"
     values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/helm/charts/39524419882dcf3d1a053711ac242c280923a094/stable/velero/values.yaml"
 spec:
   namespace: velero


### PR DESCRIPTION
This PR adds annotations intended to help the [Kubeaddons Catalog](https://github.com/kubeaddons/) track revisions to Addons. These are required for this repo to be compliant with the Catalog currently, with hopes of not needing them later.