### PR TITLE
dashboard/prometheus: use gcr.io/google_containers instead of k8s.gcr.io

### DIFF
--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -32,3 +32,8 @@ spec:
         requests:
           cpu: 500m
           memory: 300Mi
+      image:
+        # override the default k8s.gcr.io/kubernetes-dashboard-amd64 repositry
+        # containerd mirror functionality does not support pulling these images
+        # TODO remove once https://github.com/containerd/containerd/issues/3756 is resolved
+        repository: gcr.io/google_containers/kubernetes-dashboard-amd64

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -246,3 +246,9 @@ spec:
           caFile: "/etc/prometheus/secrets/etcd-certs/ca.crt"
           certFile: "/etc/prometheus/secrets/etcd-certs/server.crt"
           keyFile: "/etc/prometheus/secrets/etcd-certs/server.key"
+      kube-state-metrics:
+        image:
+          # override the default k8s.gcr.io/kube-state-metrics repositry
+          # containerd mirror functionality does not support pulling these images
+          # TODO remove once https://github.com/containerd/containerd/issues/3756 is resolved
+          repository: gcr.io/google_containers/kube-state-metrics


### PR DESCRIPTION
Cherrypick of https://github.com/mesosphere/konvoy/pull/923 to previous branch.

Containerd mirror feature can not pull k8s.gcr.io images https://github.com/containerd/containerd/issues/3756