### PR TITLE
dex-k8s-authenticator: bump to 1.1.9

### DIFF
--- a/templates/dex-k8s-authenticator.yaml
+++ b/templates/dex-k8s-authenticator.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: dex-k8s-authenticator
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.0-1"
-    appversion.kubeaddons.mesosphere.io/dex-k8s-authenticator: "v1.1.0"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.1-1"
+    appversion.kubeaddons.mesosphere.io/dex-k8s-authenticator: "v1.1.1"
     values.chart.helm.kubeaddons.mesosphere.io/dex-k8s-authenticator: "https://raw.githubusercontent.com/mesosphere/charts/6c43b8ab10108fb1adba5c6dd10e800e5f1abdd0/staging/dex-k8s-authenticator/values.yaml"
 spec:
   kubernetes:
@@ -25,12 +25,9 @@ spec:
   chartReference:
     chart: dex-k8s-authenticator
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.1.8
+    version: 1.1.9
     values: |
       ---
-      image:
-        repository: mesosphere/dex-k8s-authenticator
-        tag: v1.1.1-5e9e952-mesosphere
       ingress:
         enabled: true
         annotations:


### PR DESCRIPTION
This include the fix to the SIGTERM issue
https://github.com/mesosphere/dex-k8s-authenticator/pull/1