### PR TITLE
Add cloudProvider options in addon spec for dashboard

### DIFF
--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -15,6 +15,13 @@ metadata:
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0
+  cloudProvider:
+    - name: aws
+      enabled: true
+    - name: docker
+      enabled: true
+    - name: none
+      enabled: true
   namespace: kube-system
   chartReference:
     chart: stable/kubernetes-dashboard


### PR DESCRIPTION
This simply adds cloud provider information for the dashboard.