### PR TITLE
reloader: add new addon

### DIFF
--- a/templates/dex-k8s-authenticator.yaml
+++ b/templates/dex-k8s-authenticator.yaml
@@ -27,7 +27,7 @@ spec:
   chartReference:
     chart: dex-k8s-authenticator
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.1.9
+    version: 1.1.12
     values: |
       ---
       ingress:
@@ -55,6 +55,10 @@ spec:
         requests:
           cpu: 100m
           memory: 128Mi
+      deploymentAnnotations:
+        # The certificate can change because it was rotated or different cluster
+        # DNS name has been set.
+        secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate"
       initContainers:
       - name: initialize-dka-config
         image: mesosphere/kubeaddons-addon-initializer:v0.0.9

--- a/templates/dex.yaml
+++ b/templates/dex.yaml
@@ -25,7 +25,7 @@ spec:
   chartReference:
     chart: dex
     repo: https://mesosphere.github.io/charts/stable
-    version: 1.6.7
+    version: 1.6.10
     values: |
       ---
       # Temporarily we're going to use our custom built container. Documentation
@@ -36,6 +36,10 @@ spec:
         requests:
           cpu: 100m
           memory: 50Mi
+      deploymentAnnotations:
+        # The certificate can change because it was rotated or different cluster
+        # DNS name has been set.
+        secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate"
       ingress:
         enabled: true
         annotations:

--- a/templates/kube-oidc-proxy.yaml
+++ b/templates/kube-oidc-proxy.yaml
@@ -29,13 +29,18 @@ spec:
   chartReference:
     chart: kube-oidc-proxy
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.1.4
+    version: 0.1.7
     values: |
       ---
       image:
         repository: quay.io/jetstack/kube-oidc-proxy
         tag: v0.1.1
         pullPolicy: IfNotPresent
+
+      deploymentAnnotations:
+        # The certificate can change because it was rotated or different cluster
+        # DNS name has been set.
+        secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate"
 
       ingress:
         enabled: true

--- a/templates/reloader.yaml
+++ b/templates/reloader.yaml
@@ -1,0 +1,29 @@
+apiVersion: kubeaddons.mesosphere.io/v1beta1
+kind: Addon
+metadata:
+  name: reloader
+  namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/name: reloader
+  annotations:
+    appversion.kubeaddons.mesosphere.io/dex: "v0.0.49"
+    values.chart.helm.kubeaddons.mesosphere.io/reloader: https://raw.githubusercontent.com/stakater/Reloader/ded923b12a17a0f5c9f37f1c4594331d8d22fa70/deployments/kubernetes/chart/reloader/values.yaml
+    # catalog.kubeaddons.mesosphere.io/addon-revision: "0.0.49-1"
+spec:
+  kubernetes:
+    minSupportedVersion: v1.15.0
+  chartReference:
+    chart: reloader
+    repo: https://stakater.github.io/stakater-charts
+    version: v0.0.49
+    values: |
+      ---
+      reloader:
+        deployment:
+          resources:
+            limits:
+              cpu: "100m"
+              memory: "512Mi"
+            requests:
+              cpu: "100m"
+              memory: "128Mi"

--- a/templates/reloader.yaml
+++ b/templates/reloader.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     appversion.kubeaddons.mesosphere.io/dex: "v0.0.49"
     values.chart.helm.kubeaddons.mesosphere.io/reloader: https://raw.githubusercontent.com/stakater/Reloader/ded923b12a17a0f5c9f37f1c4594331d8d22fa70/deployments/kubernetes/chart/reloader/values.yaml
-    # catalog.kubeaddons.mesosphere.io/addon-revision: "0.0.49-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.0.49-1"
 spec:
   kubernetes:
     minSupportedVersion: v1.15.0

--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -16,7 +16,7 @@ spec:
   chartReference:
     chart: traefik-forward-auth
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.2.3
+    version: 0.2.7
     values: |
       ---
       replicaCount: 1
@@ -59,6 +59,10 @@ spec:
         hosts:
           - ""
         tls: []
+      deploymentAnnotations:
+        # The certificate can change because it was rotated or different cluster
+        # DNS name has been set.
+        secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate"
       initContainers:
       # initialize-traefik-forward-auth deploys credentials for use by the proxy
       - name: initialize-traefik-forward-auth

--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -23,7 +23,7 @@ spec:
   chartReference:
     chart: traefik
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.72.4
+    version: 1.72.7
     values: |
       ---
       replicas: 2
@@ -57,5 +57,31 @@ spec:
         # separate issue.
         # See: https://jira.mesosphere.com/browse/DCOS-56033
         insecureSkipVerify: true
+      deploymentAnnotations:
+        # Watching this CM will trigger traefik init container that updates certificate
+        # object with new DNS names. That will cascade secret update which will trigger
+        # another reload.
+        configmap.reloader.stakater.com/reload: konvoyconfig-kubeaddons
+        secret.reloader.stakater.com/reload: traefik-kubeaddons-certificate
 
-      initCertJobImage: mesosphere/kubeaddons-addon-initializer:v0.0.9
+      initContainers:
+      - name: initialize-traefik-certificate
+        image: mesosphere/kubeaddons-addon-initializer:v0.0.14
+        args: ["traefik"]
+        env:
+        - name: "TRAEFIK_INGRESS_NAMESPACE"
+          value: "kubeaddons"
+        - name: "TRAEFIK_INGRESS_SERVICE_NAME"
+          value: "traefik-kubeaddons"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_NAME"
+          value: "traefik-kubeaddons"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_ISSUER"
+          value: "kubernetes-ca"
+        - name: "TRAEFIK_INGRESS_CERTIFICATE_SECRET_NAME"
+          value: "traefik-kubeaddons-certificate"
+        - name: "TRAEFIK_KONVOY_ADDONS_CONFIG_MAP"
+          value: "konvoyconfig-kubeaddons"
+        - name: "TRAEFIK_CLUSTER_HOSTNAME_KEY"
+          value: "clusterHostname"
+
+      initCertJobImage: mesosphere/kubeaddons-addon-initializer:v0.0.14


### PR DESCRIPTION
This PR adds new https://github.com/stakater/Reloader addon.

`Reloader` allows to explicitly set rules on which deployments will get a rolling update in a case when a config map or a secret contents get updated.

The proposed annotations configure `Traefik` to reload on `konvoconfig-kubeaddons` update and certificate change. When a user sets a new `clusterHostname` domain this will trigger the first reload of traefik. The init-container will update certificate specification and adds new domain. The `cert-manager` will pick up the change and it will re-issue the certificate. The secret that holds the certificate gets updated and that will trigger the second Traefik reload.

Other components are only reloaded when traefik certificate changes.

This PR also bumps multiple charts that will use this feature.

Depends on https://github.com/mesosphere/charts/pull/210

Konvoy PR that checks that tests have passed: https://github.com/mesosphere/konvoy/pull/944