### PR TITLE
[prometheus] Upgrade thanos sidecar, scrape thanos query metrics

### DIFF
--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -73,6 +73,8 @@ spec:
                 interval: 30s
               - port: monitoring
                 interval: 30s
+              - targetPort: 10902
+                interval: 30s
           - name: kubeaddons-service-monitor-api-v1-metrics-prometheus
             selector:
               matchLabels:

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -73,6 +73,10 @@ spec:
                 interval: 30s
               - port: monitoring
                 interval: 30s
+              # Service port for Thanos Querier, running in Kommander.
+              # If we ever add a Kommander-specific Prometheus, this
+              # endpoint should be removed and added to that Prometheus's
+              # configuration.
               - targetPort: 10902
                 interval: 30s
           - name: kubeaddons-service-monitor-api-v1-metrics-prometheus

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -99,8 +99,8 @@ spec:
           image:
             tag: v2.9.2
           thanos:
-            baseImage: thanosio/thanos
-            version: v0.4.0
+            baseImage: quay.io/thanos/thanos
+            version: v0.8.1
           externalLabels:
             cluster: $(CLUSTER_ID)
           containers:


### PR DESCRIPTION
Upgrading our version of Thanos for the sidecar to v0.8.1 - tested this version with no issues. The Thanos helm chart we will be using (for Querier) is on v0.8.1 so I wanted to bring our version in line with that chart.

I've also added a service monitor endpoint to get the (future, currently in review) Thanos Querier metrics scraped. Since Kommander doesn't have its own Prometheus, we need to pull in these metrics via the "Konvoy Prometheus". If we do ever add a separate Prometheus to Kommander, we can remove this endpoint (and add it to the Kommander Prometheus config instead). The good news is that there are no issues if the specified endpoints/targets don't exist (see images). Once these metrics are scraped, we can add dashboards for Thanos Querier metrics to Kommander's Grafana.

![image](https://user-images.githubusercontent.com/5897740/67809757-8eb70000-fa56-11e9-8eed-31c031a4f113.png)

![image](https://user-images.githubusercontent.com/5897740/67809772-97a7d180-fa56-11e9-9f34-a029ab8d6605.png)
