### PR TITLE
grafana/kibana: use a sidecar container for plugins

### DIFF
--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -50,8 +50,9 @@ spec:
         requests:
           cpu: 100m
       plugins:
-        enabled: true
-        reset: true
+        # to avoid needing to download any plugins at runtime, use a container and a shared volume
+        # do not enable the plugins here, instead rebuild the mesosphere/kibana-plugins image with the new plugins
+        enabled: false
         values:
           - kibana-prometheus-exporter,6.7.0,https://github.com/pjhampton/kibana-prometheus-exporter/releases/download/6.7.0/kibana-prometheus-exporter-6.7.0.zip
       extraContainers: |
@@ -63,3 +64,16 @@ spec:
             value: "kubeaddons"
           - name: "KIBANA_SERVICE_NAME"
             value: "kibana-kubeaddons"
+      initContainers: 
+        - name: kibana-plugins-install
+          image: mesosphere/kibana-plugins:v0.0.1
+          command: ["/bin/sh", "-c", "cp -a /usr/share/kibana/plugins/. /usr/share/kibana/shared-plugins/"]
+          volumeMounts:
+          - name: plugins
+            mountPath: /usr/share/kibana/shared-plugins/
+      extraVolumes:
+        - name: plugins
+          emptyDir: {}
+      extraVolumeMounts:
+        - mountPath: /usr/share/kibana/plugins/
+          name: plugins

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -237,8 +237,20 @@ spec:
           failureThreshold: 10
         rbac:
           pspUseAppArmor: false
-        plugins:
-          - grafana-piechart-panel
+        # to avoid needing to download any plugins at runtime, use a container and a shared volume
+        # do not enable the plugins here, instead rebuild the mesosphere/grafana-plugins image with the new plugins
+        plugins: []
+        #  - grafana-piechart-panel
+        extraEmptyDirMounts:
+          - name: plugins
+            mountPath: /var/lib/grafana/plugins/
+        extraInitContainers:
+          - name: grafana-plugins-install
+            image: mesosphere/grafana-plugins:v0.0.1
+            command: ["/bin/sh", "-c", "cp -a /var/lib/grafana/plugins/. /var/lib/grafana/shared-plugins/"]
+            volumeMounts:
+            - name: plugins
+              mountPath: /var/lib/grafana/shared-plugins/
       kubeEtcd:
         enabled: true
         serviceMonitor:


### PR DESCRIPTION
To be able to support running Grafana and Kibana addons running in air-gapped environments we needed to stop downloading the plugins at startup and instead provided sidecar containers in the pod where Grafana and Kibana can used a shared volume to get the plugins.

https://github.com/mesosphere/kubeaddons-sidecars

Tested by deploying in a cluster with no internet access, before these pods would require an HTTP_PROXY env vars set.

```
➜  dkkonvoyendpoints k exec -it -n kubeaddons kibana-kubeaddons-775d7df947-sj9ht -c kibana bash
bash-4.2$ ls -la /usr/share/kibana/plugins/
total 0
drwxr-xr-x. 3 root   root  40 Oct 29 18:52 .
drwxrwsr-x. 1 kibana root  34 Mar 21  2019 ..
drwxr-sr-x. 5 kibana root 115 Oct 29 18:52 kibana-prometheus-exporter
bash-4.2$ curl -m 3 google.com
curl: (7) Failed to connect to 2607:f8b0:4004:801::200e: Network is unreachable
```
```
➜  dkkonvoyendpoints k exec -it -n kubeaddons prometheus-kubeaddons-grafana-7bfbbb65bc-k7np8 -c grafana bash
grafana@prometheus-kubeaddons-grafana-7bfbbb65bc-k7np8:/usr/share/grafana$ ls -la /var/lib/grafana/plugins/
total 0
drwxrwsrwx. 3 root    grafana  36 Oct 30 19:11 .
drwxrwsrwx. 5 root    grafana  66 Oct 30 19:21 ..
drwxr-xr-x. 6 grafana grafana 239 Oct 29 17:12 grafana-piechart-panel
grafana@prometheus-kubeaddons-grafana-7bfbbb65bc-k7np8:/usr/share/grafana$ curl -m 3 google.com
curl: (28) Connection timed out after 3000 milliseconds
```

Leaving the plugins sections there to track what plugins are already in the sidecar image.