### PR TITLE
[DCOS-59630] repository name and labels and mechanism for tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+SHELL := /bin/bash -euo pipefail
+
+.DEFAULT_GOAL := all
+
+all: create.tag push.tag
+
+.PHONY: install.python.reqs
+install.python.reqs:
+	$(shell pip install -r ./hacks/requirements.txt)
+
+.PHONY: tag.create
+tag.create:
+ifeq (, $(GIT_TAG))
+	@echo "must define a tag"
+endif
+	@echo "updating addons with tag: $(GIT_TAG)"
+	@python ./hacks/python/repository_ref_labeler.py --ref $(GIT_TAG) --path ./templates/
+	@git commit -am "changed ref labels to ${GIT_TAG}"
+	@git tag -a ${GIT_TAG} -m "${GIT_TAG}"
+	@git reset --hard HEAD^
+
+.PHONY: tag.push
+tag.push:
+ifeq (, $(GIT_TAG))
+	@echo "must define a tag"
+endif
+	@echo "pushing tag: $(GIT_TAG)"
+	@git push origin ${GIT_TAG}

--- a/hacks/python/repository_name_labeler.py
+++ b/hacks/python/repository_name_labeler.py
@@ -1,0 +1,39 @@
+from os import listdir
+from os.path import isfile, join
+from ruamel.yaml import YAML
+import argparse
+
+yaml = YAML()
+yaml.preserve_quotes = True
+
+parser = argparse.ArgumentParser(description='Place repository-name label to addons.')
+parser.add_argument('-n', '--name', help='name of repository to use')
+parser.add_argument('-p', '--path', required=True, help='path where addon files should be found')
+parser.add_argument('--remove', action='store_true', help='remove repository-name label from addons')
+args = parser.parse_args()
+
+CONST_METADATA_KEY = "metadata"
+CONST_LABEL_KEY = "labels"
+CONST_VERSION_LABEL = "kubeaddons.mesosphere.io/repository-name"
+
+addonFiles = [f for f in listdir(args.path) if isfile(join(args.path, f))]
+
+for file in addonFiles:
+    addon = open(args.path + file, "r+")
+    addonyaml = yaml.load(addon)
+    yaml.indent(mapping=2, sequence=4, offset=2)
+
+    if args.remove:
+        try:
+            del addonyaml[CONST_METADATA_KEY][CONST_LABEL_KEY][CONST_VERSION_LABEL]
+        except KeyError:
+            print("key not found in file {}, found error {}".format(file, KeyError))
+    else:
+        try:
+            addonyaml[CONST_METADATA_KEY][CONST_LABEL_KEY][CONST_VERSION_LABEL] = args.name
+            addon.seek(0)
+            addon.write("---\n")
+            yaml.dump(addonyaml, addon)
+            addon.truncate()
+        except Exception as Error:
+            print("error found in file {}: {}".format(file, Error))

--- a/hacks/python/repository_ref_labeler.py
+++ b/hacks/python/repository_ref_labeler.py
@@ -1,0 +1,39 @@
+from os import listdir
+from os.path import isfile, join
+from ruamel.yaml import YAML
+import argparse
+
+yaml = YAML()
+yaml.preserve_quotes = True
+
+parser = argparse.ArgumentParser(description='Place repository-ref label to addons.')
+parser.add_argument('-r', '--ref', help='ref of repository to use')
+parser.add_argument('-p', '--path', required=True, help='path where addon files should be found')
+parser.add_argument('--remove', action='store_true', help='remove repository-ref label from addons')
+args = parser.parse_args()
+
+CONST_METADATA_KEY = "metadata"
+CONST_LABEL_KEY = "labels"
+CONST_VERSION_LABEL = "kubeaddons.mesosphere.io/repository-ref"
+
+addonFiles = [f for f in listdir(args.path) if isfile(join(args.path, f))]
+
+for file in addonFiles:
+    addon = open(args.path + file, "r+")
+    addonyaml = yaml.load(addon)
+    yaml.indent(mapping=2, sequence=4, offset=2)
+
+    if args.remove:
+        try:
+            del addonyaml[CONST_METADATA_KEY][CONST_LABEL_KEY][CONST_VERSION_LABEL]
+        except KeyError:
+            print("key not found in file {}, found error {}".format(file, KeyError))
+    else:
+        try:
+            addonyaml[CONST_METADATA_KEY][CONST_LABEL_KEY][CONST_VERSION_LABEL] = args.ref
+            addon.seek(0)
+            addon.write("---\n")
+            yaml.dump(addonyaml, addon)
+            addon.truncate()
+        except Exception as Error:
+            print("error found in file {}: {}".format(file, Error))

--- a/hacks/python/requirements.txt
+++ b/hacks/python/requirements.txt
@@ -1,0 +1,2 @@
+ruamel.yaml==0.16.5
+ruamel.yaml.clib==0.2.0

--- a/templates/awsebscsiprovisioner.yaml
+++ b/templates/awsebscsiprovisioner.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: awsebscsiprovisioner
     kubeaddons.mesosphere.io/provides: storageclass
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "0.4.0-1"
     appversion.kubeaddons.mesosphere.io/awsebscsiprovisioner: "0.4.0"

--- a/templates/awsebsprovisioner.yaml
+++ b/templates/awsebsprovisioner.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: awsebsprovisioner
     kubeaddons.mesosphere.io/provides: storageclass
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-1"
     appversion.kubeaddons.mesosphere.io/awsebsprovisioner: "1.0"

--- a/templates/cert-manager.yaml
+++ b/templates/cert-manager.yaml
@@ -1,9 +1,12 @@
+---
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: ClusterAddon
 metadata:
   name: cert-manager
   labels:
     kubeaddons.mesosphere.io/name: cert-manager
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "0.10.1-1"
     appversion.kubeaddons.mesosphere.io/cert-manager: "0.10.1"

--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -5,6 +5,8 @@ metadata:
   name: dashboard
   labels:
     kubeaddons.mesosphere.io/name: dashboard
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.10.1-1"
     appversion.kubeaddons.mesosphere.io/dashboard: "1.10.1"

--- a/templates/defaultstorageclass-protection.yaml
+++ b/templates/defaultstorageclass-protection.yaml
@@ -1,9 +1,12 @@
+---
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: ClusterAddon
 metadata:
   name: defaultstorageclass-protection
   labels:
     kubeaddons.mesosphere.io/name: defaultstorageclass-protection
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "0.0.1-1"
     appversion.kubeaddons.mesosphere.io/defaultstorageclass-protection: "0.0.1"

--- a/templates/dex-k8s-authenticator.yaml
+++ b/templates/dex-k8s-authenticator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: Addon
 metadata:
@@ -5,6 +6,8 @@ metadata:
   namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: dex-k8s-authenticator
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.1.1-1"
     appversion.kubeaddons.mesosphere.io/dex-k8s-authenticator: "v1.1.1"

--- a/templates/dex.yaml
+++ b/templates/dex.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: Addon
 metadata:
@@ -5,6 +6,8 @@ metadata:
   namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: dex
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "2.16.0-1"
     appversion.kubeaddons.mesosphere.io/dex: "2.16.0"

--- a/templates/elasticsearch.yaml
+++ b/templates/elasticsearch.yaml
@@ -9,6 +9,8 @@ metadata:
     # TODO: we're temporarily supporting dependency on an existing default storage class
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "6.7.0-1"
     appversion.kubeaddons.mesosphere.io/elasticsearch: "6.7.0"

--- a/templates/elasticsearchexporter.yaml
+++ b/templates/elasticsearchexporter.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: elasticsearchexporter
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.2-1"
     appversion.kubeaddons.mesosphere.io/elasticsearchexporter: "1.0.2"

--- a/templates/fluentbit.yaml
+++ b/templates/fluentbit.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: fluentbit
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.2.1-1"
     appversion.kubeaddons.mesosphere.io/fluentbit: "1.2.1"

--- a/templates/gatekeeper.yaml
+++ b/templates/gatekeeper.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: Addon
 metadata:
@@ -5,6 +6,8 @@ metadata:
   namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: gatekeeper
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "3.0.4-1"
     appversion.kubeaddons.mesosphere.io/gatekeeper: "3.0.4-beta.1"

--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: kibana
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "6.7.0-1"
     appversion.kubeaddons.mesosphere.io/kibana: "6.7.0"

--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -5,6 +5,8 @@ metadata:
   name: kommander
   labels:
     kubeaddons.mesosphere.io/name: kommander
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.116.17-1"
     appversion.kubeaddons.mesosphere.io/kommander: "1.116.17"

--- a/templates/konvoyconfig.yaml
+++ b/templates/konvoyconfig.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: Addon
 metadata:
@@ -5,6 +6,8 @@ metadata:
   namespace: kubeaddons
   labels:
     kubaddons.mesosphere.io/name: konvoyconfig
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "0.0.1-1"
     appversion.kubeaddons.mesosphere.io/konvoyconfig: "0.0.1"

--- a/templates/kube-oidc-proxy.yaml
+++ b/templates/kube-oidc-proxy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: Addon
 metadata:
@@ -5,6 +6,8 @@ metadata:
   namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: kube-oidc-proxy
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "0.1.1-1"
     appversion.kubeaddons.mesosphere.io/kube-oidc-proxy: "v0.1.1"

--- a/templates/kudo.yaml
+++ b/templates/kudo.yaml
@@ -1,9 +1,12 @@
+---
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: ClusterAddon
 metadata:
   name: kudo
   labels:
     kubeaddons.mesosphere.io/name: kudo
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "0.7.4-1"
     appversion.kubeaddons.mesosphere.io/kudo: "0.7.4"

--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: localvolumeprovisioner
     kubeaddons.mesosphere.io/provides: storageclass
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-1"
     appversion.kubeaddons.mesosphere.io/localvolumeprovisioner: "1.0"

--- a/templates/metallb.yaml
+++ b/templates/metallb.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: ClusterAddon
 metadata:
@@ -5,6 +6,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: metallb
     kubeaddons.mesosphere.io/provides: loadbalancer
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "0.7.3-1"
     appversion.kubeaddons.mesosphere.io/metallb: "0.7.3"

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: nvidia
     kubeaddons.mesosphere.io/provides: nvidia
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "0.1.0-1"
     appversion.kubeaddons.mesosphere.io/nvidia: "0.1"

--- a/templates/opsportal.yaml
+++ b/templates/opsportal.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: Addon
 metadata:
@@ -5,6 +6,8 @@ metadata:
   namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: opsportal
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.0-1"
     appversion.kubeaddons.mesosphere.io/opsportal: "1.0.0"

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: Addon
 metadata:
@@ -8,6 +9,8 @@ metadata:
     # TODO: we're temporarily supporting dependency on an existing default storage class
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "0.31.1-1"
     appversion.kubeaddons.mesosphere.io/prometheus-operator: "0.31.1"

--- a/templates/prometheusadapter.yaml
+++ b/templates/prometheusadapter.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: prometheusadapter
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "0.5.0-1"
     appversion.kubeaddons.mesosphere.io/prometheusadapter: "0.5.0"

--- a/templates/reloader.yaml
+++ b/templates/reloader.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: Addon
 metadata:
@@ -5,6 +6,8 @@ metadata:
   namespace: kubeaddons
   labels:
     kubeaddons.mesosphere.io/name: reloader
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     appversion.kubeaddons.mesosphere.io/dex: "v0.0.49"
     values.chart.helm.kubeaddons.mesosphere.io/reloader: https://raw.githubusercontent.com/stakater/Reloader/ded923b12a17a0f5c9f37f1c4594331d8d22fa70/deployments/kubernetes/chart/reloader/values.yaml

--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -1,8 +1,12 @@
+---
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: Addon
 metadata:
   name: traefik-forward-auth
   namespace: kubeaddons
+  labels:
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.4-1"
 spec:

--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: ClusterAddon
 metadata:
@@ -8,6 +9,8 @@ metadata:
     # TODO: we're temporarily supporting dependency on an existing default storage class
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.68.4-1"
     appversion.kubeaddons.mesosphere.io/traefik: "1.68.4"

--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -1,3 +1,4 @@
+---
 # ------------------------------------------------------------------------------
 # Velero
 #
@@ -19,7 +20,6 @@
 #
 # WARNING: using the default (fallback) backend is for testing purposes only and should not be used in production.
 # ------------------------------------------------------------------------------
----
 apiVersion: kubeaddons.mesosphere.io/v1beta1
 kind: ClusterAddon
 metadata:
@@ -29,6 +29,8 @@ metadata:
     # TODO: we're temporarily supporting dependency on an existing default storage class
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
+    kubeaddons.mesosphere.io/repository-name: kubeaddons-configs
+    kubeaddons.mesosphere.io/repository-ref: master
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.0.1-1"
     values.chart.helm.kubeaddons.mesosphere.io/velero: "https://raw.githubusercontent.com/helm/charts/39524419882dcf3d1a053711ac242c280923a094/stable/velero/values.yaml"


### PR DESCRIPTION
This PR provides:

Repository name and ref labels for all addons. 

It also includes a mechanism for creating new tags and pushing them when we wish to update the refs and create a new tag to be used by konvoy. For now this is a manual process with the hopes of creating an automated process in the future.  

sample run:
```
$ GIT_TAG=alejandro make tag.create
updating addons with tag: alejandro
[ae/kubeaddonsversions 92c8767] changed ref labels to alejandro
 26 files changed, 26 insertions(+), 26 deletions(-)
HEAD is now at 76dd106 makefile updated
```
then we should push the tag:

```
$ GIT_TAG=alejandro make tag.push
echo "pushing tag: alejandro"
pushing tag: alejandro
git push origin alejandro
Enumerating objects: 56, done.
Counting objects: 100% (56/56), done.
Delta compression using up to 12 threads
Compressing objects: 100% (30/30), done.
Writing objects: 100% (30/30), 3.39 KiB | 3.39 MiB/s, done.
Total 30 (delta 27), reused 0 (delta 0)
remote: Resolving deltas: 100% (27/27), completed with 25 local objects.
To github.com:mesosphere/kubeaddons-configs.git
 * [new tag]         alejandro -> alejandro
```

at this point the tag `alejandro` exists and has the right ref as expected



