### PR TITLE
traefik: bump chart, catalog and initializer version

### DIFF
--- a/templates/traefik.yaml
+++ b/templates/traefik.yaml
@@ -10,7 +10,7 @@ metadata:
     # on the cluster, this hack will trigger re-queue on Addons until one exists.
     kubeaddons.mesosphere.io/hack-requires-defaultstorageclass: "true"
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.68.4-1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.68.4-2"
     appversion.kubeaddons.mesosphere.io/traefik: "1.68.4"
     endpoint.kubeaddons.mesosphere.io/traefik: "/ops/portal/traefik"
     docs.kubeaddons.mesosphere.io/traefik: "https://docs.traefik.io/v1.7"
@@ -24,7 +24,7 @@ spec:
   chartReference:
     chart: traefik
     repo: https://mesosphere.github.io/charts/staging
-    version: 1.72.7
+    version: 1.72.8
     values: |
       ---
       replicas: 2
@@ -67,7 +67,7 @@ spec:
 
       initContainers:
       - name: initialize-traefik-certificate
-        image: mesosphere/kubeaddons-addon-initializer:v0.0.14
+        image: mesosphere/kubeaddons-addon-initializer:v0.1.2
         args: ["traefik"]
         env:
         - name: "TRAEFIK_INGRESS_NAMESPACE"
@@ -85,4 +85,4 @@ spec:
         - name: "TRAEFIK_CLUSTER_HOSTNAME_KEY"
           value: "clusterHostname"
 
-      initCertJobImage: mesosphere/kubeaddons-addon-initializer:v0.0.14
+      initCertJobImage: mesosphere/kubeaddons-addon-initializer:v0.1.2


### PR DESCRIPTION
kubeaddons-extrasteps changes: https://github.com/mesosphere/kubeaddons-extrasteps/pull/26
traefik chart changes: https://github.com/mesosphere/charts/pull/221
initializer release: https://github.com/mesosphere/kubeaddons-extrasteps/releases