### PR TITLE
dex-k8s-authenticator: bump versions for distributed auth

### DIFF
--- a/templates/dex-k8s-authenticator.yaml
+++ b/templates/dex-k8s-authenticator.yaml
@@ -31,6 +31,9 @@ spec:
     version: 1.1.12
     values: |
       ---
+      image:
+        repository: mesosphere/dex-k8s-authenticator
+        tag: v1.1.0-e21a70-mesosphere
       ingress:
         enabled: true
         annotations:
@@ -62,7 +65,7 @@ spec:
         secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate"
       initContainers:
       - name: initialize-dka-config
-        image: mesosphere/kubeaddons-addon-initializer:v0.0.9
+        image: mesosphere/kubeaddons-addon-initializer:v0.1.3
         args: ["dexK8sAuthenticator"]
         env:
         - name: "DKA_CONFIGMAP_NAME"

--- a/templates/dex.yaml
+++ b/templates/dex.yaml
@@ -89,6 +89,7 @@ spec:
           name: 'Kubernetes CLI authenticator'
           redirectURIs:
             - 'https://PUBLIC.URI/token/callback/kubernetes-cluster'
+            - 'https://PUBLIC.URI/token/callback'
         - id: traefik-forward-auth
           name: 'Ops Portal authenticator'
           redirectURIs:


### PR DESCRIPTION
Testing in https://github.com/mesosphere/konvoy/pull/964