### PR TITLE
kube-oidc-proxy: add the missing group claim

### DIFF
--- a/templates/kube-oidc-proxy.yaml
+++ b/templates/kube-oidc-proxy.yaml
@@ -62,6 +62,7 @@ spec:
         # updated by initcontainer when working with a remote dex
         issuerUrl: https://dex-kubeaddons.kubeaddons.svc.cluster.local:8080/dex
         usernameClaim: email
+        groupsClaim: groups
         groupsPrefix: "oidc:"
         # placeholder : updated by initcontainer
         caPEM: "placeholder"


### PR DESCRIPTION
Otherwise, the group based RBAC won't work because the proxy does not
know which claim from the JWT token to look for.

Tested manually using the following test LDAP server
https://github.com/mesosphere/dex-controller/blob/master/config/samples/ldap_connector.yaml
https://github.com/mesosphere/dex-controller/blob/master/config/samples/ldap_password.yaml

Also this CRB:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: scientists-admin
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: cluster-admin
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: Group
  name: oidc:scientists
```

And login using:
```
username: tesla
password: password
```