### PR TITLE
dex-k8s-authenticator: reload pod on config change

### DIFF
--- a/templates/dex-k8s-authenticator.yaml
+++ b/templates/dex-k8s-authenticator.yaml
@@ -63,6 +63,7 @@ spec:
         # The certificate can change because it was rotated or different cluster
         # DNS name has been set.
         secret.reloader.stakater.com/reload: "traefik-kubeaddons-certificate"
+        configmap.reloader.stakater.com/reload: "dex-k8s-authenticator-kubeaddons"
       initContainers:
       - name: initialize-dka-config
         image: mesosphere/kubeaddons-addon-initializer:v0.1.3


### PR DESCRIPTION
Automatically reload `dex-k8s-authenticator` on its config map change.

This is necessary when DKA controller adds new managed cluster to the config map.