### PR TITLE
kommander: update chart version to 0.1.53

### DIFF
--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -27,7 +27,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.1.54
+    version: 0.1.55
     values: |
       ---
       ingress:


### PR DESCRIPTION
This will pull in the grafana dashboard for Thanos Query metrics on Kommander. Blocked on https://github.com/mesosphere/charts/pull/231, once that is merged, this is good to go.