### PR TITLE
Bump Nvidia chart version and make nvidia driver image tag configurable.

### DIFF
--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -7,9 +7,9 @@ metadata:
     kubeaddons.mesosphere.io/name: nvidia
     kubeaddons.mesosphere.io/provides: nvidia
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.1.0-1"
-    appversion.kubeaddons.mesosphere.io/nvidia: "0.1"
-    values.chart.helm.kubeaddons.mesosphere.io/nvidia: "https://raw.githubusercontent.com/mesosphere/charts/869a26a8d4061d5b407cd260eac2eee9149f2823/staging/nvidia/values.yaml"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.1.1-1"
+    appversion.kubeaddons.mesosphere.io/nvidia: "0.1.1"
+    values.chart.helm.kubeaddons.mesosphere.io/nvidia: "https://raw.githubusercontent.com/mesosphere/charts/master/staging/nvidia/values.yaml"
 spec:
   namespace: kube-system
   kubernetes:
@@ -22,7 +22,7 @@ spec:
   chartReference:
     chart: nvidia
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.1.1
+    version: 0.1.2
     values: |
       ---
       nvidia-driver:

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -16,16 +16,18 @@ spec:
     minSupportedVersion: v1.15.0
   cloudProvider:
     - name: aws
-      enabled: false
+      enabled: true
     - name: none
-      enabled: false
+      enabled: true
   chartReference:
     chart: nvidia
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.1.0
+    version: 0.1.1
     values: |
       ---
       nvidia-driver:
+        image:
+          tag: "418.87.01-centos7"
         resources:
           limits:
              cpu: 2000m

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -16,9 +16,9 @@ spec:
     minSupportedVersion: v1.15.0
   cloudProvider:
     - name: aws
-      enabled: true
+      enabled: false
     - name: none
-      enabled: true
+      enabled: false
   chartReference:
     chart: nvidia
     repo: https://mesosphere.github.io/charts/staging


### PR DESCRIPTION
Bump the Nvidia helm chart to 0.1.2, which includes the image update for nvidia driver and nvidia device plugin.

Add the default nvidia driver image tag for centos, which make it configurable in Konvoy cluster.yaml.