### PR TITLE
Add priority to ingress

### DIFF
--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -55,6 +55,7 @@ spec:
           ingress.kubernetes.io/protocol: https
           traefik.ingress.kubernetes.io/auth-type: forward
           traefik.ingress.kubernetes.io/auth-url: http://traefik-forward-auth-kubeaddons.kubeaddons.svc.cluster.local:4181/
+          traefik.ingress.kubernetes.io/priority: "1"
         paths:
           - /_oauth
         hosts:


### PR DESCRIPTION
For identical roles, a priority annotation must exist on all ingress definitions in order to override the ingress definition with another. 