### PR TITLE
Bump kubeaddons-addon-initializer for dex

### DIFF
--- a/templates/dex.yaml
+++ b/templates/dex.yaml
@@ -96,7 +96,7 @@ spec:
             - 'https://PUBLIC.URI/_oauth'
       initContainers:
       - name: initialize-dex
-        image: mesosphere/kubeaddons-addon-initializer:v0.0.9
+        image: mesosphere/kubeaddons-addon-initializer:v0.1.5
         args: ["dex"]
         env:
         - name: "DEX_NAMESPACE"


### PR DESCRIPTION
This version fixes a bug causing dex static clients to be overwritten