### PR TITLE
tfa: backport the whitelist/domain bug

### DIFF
--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -12,7 +12,7 @@ spec:
   chartReference:
     chart: traefik-forward-auth
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.2.0
+    version: 0.2.1
     values: |
       ---
       replicaCount: 1


### PR DESCRIPTION
This backports the following fix to stable/1.15.5 branch.
https://github.com/mesosphere/charts/pull/135