### PR TITLE
kommander: Reload karma configmap on edit

### DIFF
--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -40,3 +40,9 @@ spec:
           issuer:
             name: kubernetes-ca
             kind: ClusterIssuer
+
+      kommander-karma:
+        karma:
+          deployment:
+            annotations:
+              configmap.reloader.stakater.com/reload: kommander-kubeaddons-config

--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -28,7 +28,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.2.8
+    version: 0.2.9
     values: |
       ---
       ingress:


### PR DESCRIPTION
This bumps kommander and adds configuration that directs the reloader addon to restart kommander's karma deployment if its configmap is edited.

I tested this by deploying a Konvoy cluster using this branch's addons, and then adding an alertmanager entry to karma's configmap. This caused karma to be redeployed, and the new pod's logs mentioned the added alertmanager.