### PR TITLE
bump kudo chart to 0.1.2

### DIFF
--- a/templates/kudo.yaml
+++ b/templates/kudo.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kudo
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.7.4-1"
-    appversion.kubeaddons.mesosphere.io/kudo: "0.7.4"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.8.0"
+    appversion.kubeaddons.mesosphere.io/kudo: "0.8.0"
 spec:
   namespace: kube-system
   kubernetes:
@@ -24,4 +24,4 @@ spec:
   chartReference:
     chart: kudo
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.1.1
+    version: 0.1.2


### PR DESCRIPTION
Once the https://github.com/mesosphere/charts/pull/257 is merged we need to update the KUDO addon to use the version `0.8.0` of the KUDO 