### PR TITLE
feat(istio): add version & docs for istio UI cards

### DIFF
--- a/templates/istio.yaml
+++ b/templates/istio.yaml
@@ -8,9 +8,13 @@ metadata:
   annotations:
     catalog.kubeaddons.mesosphere.io/addon-revision: "1.3.3-1"
     appversion.kubeaddons.mesosphere.io/istio: "1.3.3"
+    appversion.kubeaddons.mesosphere.io/kiali: "1.3.3"
+    appversion.kubeaddons.mesosphere.io/jaeger: "1.3.3"
     endpoint.kubeaddons.mesosphere.io/kiali: "/ops/portal/kiali"
     endpoint.kubeaddons.mesosphere.io/jaeger: "/ops/portal/jaeger"
     docs.kubeaddons.mesosphere.io/istio: "https://istio.io/docs/"
+    docs.kubeaddons.mesosphere.io/kiali: "https://istio.io/docs/tasks/telemetry/kiali/"
+    docs.kubeaddons.mesosphere.io/jaeger: "https://istio.io/docs/tasks/telemetry/distributed-tracing/jaeger/"
     values.chart.helm.kubeaddons.mesosphere.io/istio: "https://raw.githubusercontent.com/mesosphere/charts/63bbc17eda76f2136f6ab4f6d6eef7e764e5f0a5/staging/istio/values.yaml"
 spec:
   namespace: istio-system


### PR DESCRIPTION
- Adding `appversion` & `docs` annotations for both `kiali` & `jaegar` so that their UI service cards will display the correct version and docs links.