### PR TITLE
templates: fix docker for the local volume provisioner

### DIFF
--- a/templates/localvolumeprovisioner.yaml
+++ b/templates/localvolumeprovisioner.yaml
@@ -18,6 +18,8 @@ spec:
   kubernetes:
     minSupportedVersion: v1.15.0
   cloudProvider:
+    - name: docker
+      enabled: true
     - name: aws
       enabled: false
       values: |


### PR DESCRIPTION
It seems this got merged but there was a wrong property set here: https://github.com/mesosphere/kubeaddons-configs/commit/0a5057a1f3dc7603ea3d40386fea88f149caa8d9#diff-940268ba9fc726ba58c83765edbbbf52