### PR TITLE
enable default setting for service in external-dns

### DIFF
--- a/templates/external-dns.yaml
+++ b/templates/external-dns.yaml
@@ -31,5 +31,3 @@ spec:
     values: |
       rbac:
         create: true
-      sources:
-      - ingress


### PR DESCRIPTION
By default, external-dns watches service and ingress objects for external DNS configuration. This PR enables that default setting