### PR TITLE
kommander: version bump

### DIFF
--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -30,7 +30,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.2.11
+    version: 0.2.12
     values: |
       ---
       ingress:


### PR DESCRIPTION
Bumps kommander to 0.2.12 to pull in the dashboard for multi-cluster view of cpu/mem