### PR TITLE
Revert "chore: bump kommander/opsportal charts for new image tag 1.150.5"

### DIFF
--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.150.5-1"
-    appversion.kubeaddons.mesosphere.io/kommander: "1.150.5"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.149.77-1"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.149.77"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander
     values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/master/stable/kommander/values.yaml"
     helmv2.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=0.1.22\", \"strategy\": \"delete\"}]"
@@ -30,7 +30,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.2.17
+    version: 0.2.16
     values: |
       ---
       ingress:

--- a/templates/opsportal.yaml
+++ b/templates/opsportal.yaml
@@ -26,7 +26,7 @@ spec:
   chartReference:
     chart: opsportal
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.1.18
+    version: 0.1.16
     values: |
       ---
       bearerproxy:


### PR DESCRIPTION
CI is broken in Konvoy at this moment. Both AWS and Docker builds are broken with the following error:
https://teamcity.mesosphere.io/viewLog.html?buildId=2447341&buildTypeId=ClosedSource_Konvoy_KonvoyE2eDocker&tab=buildLog&_focus=6659
all builds are red https://teamcity.mesosphere.io/viewLog.html?buildId=2447341&buildTypeId=ClosedSource_Konvoy_KonvoyE2eDocker