### PR TITLE
chore(kommander): Upgrade kubeaddons-configs mapping to kommander-beta6

### DIFF
--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -48,7 +48,7 @@ spec:
           versionStrategy: mapped-kubernetes-version
           versionMap:
             1.15.4: kommander-beta4
-            1.15.5: kommander-beta5
+            1.15.5: kommander-beta6
 
       kommander-karma:
         karma:


### PR DESCRIPTION
Necessary until we do proper tagging in kubeaddons-configs.