### PR TITLE
chore: bump addons versions to support Kubernetes v1.16

### DIFF
--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -26,7 +26,7 @@ spec:
       enabled: true
   chartReference:
     chart: stable/kubernetes-dashboard
-    version: 1.5.2
+    version: 1.10.1
     values: |
       ---
       # so that kubectl proxy works

--- a/templates/dispatch.yaml
+++ b/templates/dispatch.yaml
@@ -30,7 +30,7 @@ spec:
   chartReference:
     chart: dispatch
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.3.3
+    version: 0.3.5
     values: |
       ---
       global:

--- a/templates/elasticsearch.yaml
+++ b/templates/elasticsearch.yaml
@@ -27,7 +27,7 @@ spec:
       enabled: true
   chartReference:
     chart: stable/elasticsearch
-    version: 1.26.2
+    version: 1.32.0
     values: |
       ---
       client:

--- a/templates/elasticsearchexporter.yaml
+++ b/templates/elasticsearchexporter.yaml
@@ -27,15 +27,11 @@ spec:
         kubeaddons.mesosphere.io/name: elasticsearch
   chartReference:
     chart: stable/elasticsearch-exporter
-    version: 1.3.1
+    version: 2.1.1
     values: |
       ---
       es:
         uri: http://elasticsearch-kubeaddons-client:9200
-      image:
-        repository: justwatch/elasticsearch_exporter
-        tag: 1.0.2
-        pullPolicy: IfNotPresent
       service:
         labels:
           servicemonitor.kubeaddons.mesosphere.io/path: "metrics"

--- a/templates/fluentbit.yaml
+++ b/templates/fluentbit.yaml
@@ -24,7 +24,7 @@ spec:
       enabled: true
   chartReference:
     chart: stable/fluent-bit
-    version: 2.0.5
+    version: 2.8.2
     values: |
       ---
       backend:

--- a/templates/kibana.yaml
+++ b/templates/kibana.yaml
@@ -29,7 +29,7 @@ spec:
         kubeaddons.mesosphere.io/name: elasticsearch
   chartReference:
     chart: stable/kibana
-    version: 3.0.0
+    version: 3.2.4
     values: |
       ---
       files:

--- a/templates/metallb.yaml
+++ b/templates/metallb.yaml
@@ -36,7 +36,7 @@ spec:
             addresses: []
   chartReference:
     chart: stable/metallb
-    version: 0.9.5
+    version: 0.12.0
     values: |
       ---
       controller:

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -37,7 +37,7 @@ spec:
   chartReference:
     chart: prometheus-operator
     repo: https://mesosphere.github.io/charts/staging
-    version: 5.19.2
+    version: 5.19.6
     values: |
       ---
       defaultRules:

--- a/templates/velero.yaml
+++ b/templates/velero.yaml
@@ -46,7 +46,7 @@ spec:
   chartReference:
     chart: velero
     repo: https://mesosphere.github.io/charts/staging
-    version: 2.2.5
+    version: 2.2.9
     values: |
       ---
       configuration:


### PR DESCRIPTION
Blocked by https://github.com/mesosphere/charts/pull/283

Bumped all the upstream chart versions to support Kubernetes v1.16 apis.

Ran Konvoy and the tests passed, https://github.com/mesosphere/konvoy/pull/1025 (the one failure was unrelated).
This includes an test where we upgrade from Konvoy v1.1.x release to the release and all the addons got upgraded successfully. 

Tested a bunch of times manually also.