### PR TITLE
kommander: Bump to v0.2.19

### DIFF
--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -30,7 +30,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.2.18
+    version: 0.2.19
     values: |
       ---
       ingress:


### PR DESCRIPTION
Bump kommander to pull in kommander's prometheus datasource to populate the thanos querier dashboard, see: https://github.com/mesosphere/charts/pull/279