### PR TITLE
Bumped the Nvidia chart version to support GPU metrics.

### DIFF
--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -53,6 +53,8 @@ spec:
           image: busybox
           command: ['sh', '-c', 'sleep 180']
       nvidia-dcgm-exporter:
+        enabled: true
+        namespace: kubeaddons
         nodeSelector:
           konvoy.mesosphere.com/gpu-provider: NVIDIA
         initContainers:

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -51,4 +51,4 @@ spec:
         initContainers:
         - name: init-wait
           image: busybox
-          command: ['sh', '-c', 'sleep 90']
+          command: ['sh', '-c', 'sleep 180']

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -52,3 +52,10 @@ spec:
         - name: init-wait
           image: busybox
           command: ['sh', '-c', 'sleep 180']
+      nvidia-dcgm-exporter:
+        nodeSelector:
+          konvoy.mesosphere.com/gpu-provider: NVIDIA
+        initContainers:
+        - name: init-wait
+          image: busybox
+          command: ['sh', '-c', 'sleep 200']

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -34,7 +34,7 @@ spec:
           tag: "418.87.01-centos7"
         resources:
           requests:
-             cpu: 200m
+             cpu: 500m
              memory: 512Mi
         nodeSelector:
           konvoy.mesosphere.com/gpu-provider: NVIDIA

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -61,3 +61,6 @@ spec:
         - name: init-wait
           image: busybox
           command: ['sh', '-c', 'sleep 200']
+      grafana:
+        enabled: true
+        namespace: kubeaddons

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -33,12 +33,9 @@ spec:
         image:
           tag: "418.87.01-centos7"
         resources:
-          limits:
-             cpu: 2000m
-             memory: 6144Mi
           requests:
              cpu: 200m
-             memory: 256Mi
+             memory: 512Mi
         nodeSelector:
           konvoy.mesosphere.com/gpu-provider: NVIDIA
       nvidia-device-plugin:

--- a/templates/nvidia.yaml
+++ b/templates/nvidia.yaml
@@ -7,8 +7,8 @@ metadata:
     kubeaddons.mesosphere.io/name: nvidia
     kubeaddons.mesosphere.io/provides: nvidia
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "0.1.1-1"
-    appversion.kubeaddons.mesosphere.io/nvidia: "0.1.1"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "0.2.0-1"
+    appversion.kubeaddons.mesosphere.io/nvidia: "0.2.0"
     values.chart.helm.kubeaddons.mesosphere.io/nvidia: "https://raw.githubusercontent.com/mesosphere/charts/master/staging/nvidia/values.yaml"
 spec:
   namespace: kube-system
@@ -26,7 +26,7 @@ spec:
   chartReference:
     chart: nvidia
     repo: https://mesosphere.github.io/charts/staging
-    version: 0.1.2
+    version: 0.2.0
     values: |
       ---
       nvidia-driver:

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -140,6 +140,22 @@ spec:
                   regex: '(.*):10250'
                   replacement: '${1}:1338'
                   target_label: __address__
+            - job_name: 'gpu_metrics'
+              scrape_interval: 1s
+              metrics_path: /gpu/metrics
+              tls_config:
+                ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              kubernetes_sd_configs:
+                - role: node
+              relabel_configs:
+                - source_labels: [__address__]
+                  regex: '(.*):10250'
+                  replacement: '${1}:9400'
+                  target_label: __address__
+                - source_labels: [__meta_kubernetes_node_label_konvoy_mesosphere_com_gpu_provider]
+                  regex: NVIDIA
+                  action: keep
             - job_name: 'kubernetes-calico-node'
               metrics_path: /metrics
               tls_config:

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -141,7 +141,6 @@ spec:
                   replacement: '${1}:1338'
                   target_label: __address__
             - job_name: 'gpu_metrics'
-              scrape_interval: 1s
               metrics_path: /gpu/metrics
               tls_config:
                 ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt


### PR DESCRIPTION
This PR bumps the Nvidia chart version to 0.2.0, which contains the GPU metrics and granfana dashboard support.

It also removes the limits for GPU driver daemonset, because GPU is considered as dedicated resources and we do not want to add limited resources to those mission critical tasks like GPU driver, to avoid dependent applications being affected if the driver being OOM killed.

This PR depends on the helm chart PR https://github.com/mesosphere/charts/pull/285

<img width="2540" alt="Screen Shot 2019-11-26 at 3 27 32 PM" src="https://user-images.githubusercontent.com/12464168/69681041-a687a100-1061-11ea-8575-a949dff9f78e.png">
<img width="2545" alt="Screen Shot 2019-11-26 at 3 29 20 PM" src="https://user-images.githubusercontent.com/12464168/69681045-a8e9fb00-1061-11ea-9fee-943bf7c293a5.png">
