### PR TITLE
chore: bump kommander chart to 0.2.26

### DIFF
--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -30,7 +30,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.2.25
+    version: 0.2.26
     values: |
       ---
       ingress:


### PR DESCRIPTION
Cherrypicked to kommander-beta7 branch.