### PR TITLE
bump tfa to 1.0.6

### DIFF
--- a/templates/traefik-forward-auth.yaml
+++ b/templates/traefik-forward-auth.yaml
@@ -23,7 +23,7 @@ spec:
       replicaCount: 1
       image:
         repository: mesosphere/traefik-forward-auth
-        tag: 1.0.5
+        tag: 1.0.6
         pullPolicy: IfNotPresent
       resources:
         requests:


### PR DESCRIPTION
legacy patch for tfa, also https://github.com/mesosphere/kubernetes-base-addons/pull/13 for konvoy 1.3+