### PR TITLE
chore: bump kommander/opsportal 1.171.10

### DIFF
--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -6,8 +6,8 @@ metadata:
   labels:
     kubeaddons.mesosphere.io/name: kommander
   annotations:
-    catalog.kubeaddons.mesosphere.io/addon-revision: "1.169.3-1"
-    appversion.kubeaddons.mesosphere.io/kommander: "1.169.3"
+    catalog.kubeaddons.mesosphere.io/addon-revision: "1.171.10-1"
+    appversion.kubeaddons.mesosphere.io/kommander: "1.171.10"
     endpoint.kubeaddons.mesosphere.io/kommander: /ops/portal/kommander
     values.chart.helm.kubeaddons.mesosphere.io/kommander: "https://raw.githubusercontent.com/mesosphere/charts/master/stable/kommander/values.yaml"
     helmv2.kubeaddons.mesosphere.io/upgrade-strategy: "[{\"upgradeFrom\": \"<=0.1.22\", \"strategy\": \"delete\"}]"
@@ -30,7 +30,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.2.28
+    version: 0.2.30
     values: |
       ---
       ingress:

--- a/templates/opsportal.yaml
+++ b/templates/opsportal.yaml
@@ -26,7 +26,7 @@ spec:
   chartReference:
     chart: opsportal
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.1.22
+    version: 0.1.23
     values: |
       ---
       landing:


### PR DESCRIPTION
depends on https://github.com/mesosphere/charts/pull/316

seems like this repo is still used? updating here as well. same question as in https://github.com/mesosphere/kubernetes-base-addons/pull/26 : that opsportal link pointed to a specific git sha and was therefore never actually updated 🤔 bug?