### PR TITLE
kommander: bump chart to 0.2.29

### DIFF
--- a/templates/kommander.yaml
+++ b/templates/kommander.yaml
@@ -30,7 +30,7 @@ spec:
   chartReference:
     chart: kommander
     repo: https://mesosphere.github.io/charts/stable
-    version: 0.2.28
+    version: 0.2.29
     values: |
       ---
       ingress:


### PR DESCRIPTION
Blocked by https://github.com/mesosphere/charts/pull/318 - once that is merged, I will modify the chart repo to point back to `mesosphere`.

## Testing
See the Testing section in https://github.com/mesosphere/charts/pull/318#issue-354269295